### PR TITLE
Add `parent` to `FieldConfigItem` to wrap field with tag

### DIFF
--- a/src/components/ui/auto-form.tsx
+++ b/src/components/ui/auto-form.tsx
@@ -150,10 +150,24 @@ function zodToHtmlInputProps(
   return inputProps;
 }
 
+type HtmlTag = 
+  | 'div'
+  | 'fieldset'
+  | 'form'
+  | 'label'
+  | 'li'
+  | 'td';
+
 export type FieldConfigItem = {
   description?: React.ReactNode;
   inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
   fieldType?: keyof typeof INPUT_COMPONENTS;
+  parent?: {
+    tag: HtmlTag;
+    props: {
+      [key: string]: any;
+    }
+  };
 
   startAdornment?: React.ReactNode;
   endAdornment?: React.ReactNode;
@@ -378,9 +392,11 @@ function AutoFormObject<SchemaType extends z.ZodObject<any, any>>({
                 DEFAULT_ZOD_HANDLERS[zodBaseType] ??
                 "fallback";
               const InputComponent = INPUT_COMPONENTS[inputType];
+              const ParentComponent = fieldConfigItem.parent ? fieldConfigItem.parent.tag : React.Fragment;
+              const parentProps = fieldConfigItem.parent?.props ?? {};
 
               return (
-                <React.Fragment key={name}>
+                <ParentComponent key={name} {...parentProps}>
                   {fieldConfigItem.startAdornment}
                   <InputComponent
                     zodInputProps={zodInputProps}
@@ -396,7 +412,7 @@ function AutoFormObject<SchemaType extends z.ZodObject<any, any>>({
                     }}
                   />
                   {fieldConfigItem.endAdornment}
-                </React.Fragment>
+                </ParentComponent>
               );
             }}
           />


### PR DESCRIPTION
Great work on this! Here's something I needed right away.

Usage:

```tsx
<AutoForm
  formSchema={formSchema}
  fieldConfig={{
    firstName: {
      inputProps: {
        placeholder: 'Joseph'
      },
      parent: {
        tag: 'div',
        props: {
          className: 'col-span-1'
        }
      }
    },
  }}
  onSubmit={onSubmit}
>
  <Button type="submit">Submit</Button>
</AutoForm>

// This will be rendered as:
<div className='col-span-1'>
  <input type="text" placeholder="Joseph" /* ... */ />
</div>