### PR TITLE
feat: number input

### DIFF
--- a/src/components/ui/auto-form.tsx
+++ b/src/components/ui/auto-form.tsx
@@ -234,6 +234,33 @@ function AutoFormInput({
   );
 }
 
+function AutoFormNumberInput({
+  label,
+  isRequired,
+  fieldConfigItem,
+  fieldProps,
+}: AutoFormInputComponentProps) {
+  return (
+    <FormItem>
+      <FormLabel>
+        {label}
+        {isRequired && <span className="text-destructive"> *</span>}
+      </FormLabel>
+      <FormControl>
+        <Input
+          {...fieldProps}
+          type="number"
+          onChange={(e) => fieldProps.onChange(e.target.valueAsNumber)}
+        />
+      </FormControl>
+      {fieldConfigItem.description && (
+        <FormDescription>{fieldConfigItem.description}</FormDescription>
+      )}
+      <FormMessage />
+    </FormItem>
+  );
+}
+
 function AutoFormTextarea({
   label,
   isRequired,
@@ -429,6 +456,7 @@ const INPUT_COMPONENTS = {
   radio: AutoFormRadioGroup,
   switch: AutoFormSwitch,
   textarea: AutoFormTextarea,
+  number: AutoFormNumberInput,
   fallback: AutoFormInput,
 };
 


### PR DESCRIPTION
- clones `input` with `type="number"` for number inputs
> setting `type="number"` through input props is not enough. State persists being string, therefore form validators error