### PR TITLE
feat(select): placeholder

### DIFF
--- a/src/components/ui/auto-form.tsx
+++ b/src/components/ui/auto-form.tsx
@@ -426,7 +426,9 @@ function AutoFormEnum({
       <FormControl>
         <Select onValueChange={field.onChange} defaultValue={field.value}>
           <SelectTrigger>
-            <SelectValue className="w-full">
+            <SelectValue 
+              className="w-full" 
+              placeholder={fieldConfigItem.inputProps?.placeholder}>
               {field.value ?? "Select an option"}
             </SelectValue>
           </SelectTrigger>


### PR DESCRIPTION
- includes `placeholder` to `SelectValue`

You can now pass a custom `Select` placeholder
```ts
<Autoform 
  formSchema={schema}
  fieldConfig={{
    myEnumField: { 
      inputProps: { placeholder: "Custom Select Placeholder" } 
    }
  }}
/>
```

> `?? "Select an option"` should be default on placeholder but having only the field value on `SelectValue` content causes the first select to be empty for some reason,