### PR TITLE
Fix "required" to be OR instead of coalesce

### DIFF
--- a/src/components/ui/auto-form.tsx
+++ b/src/components/ui/auto-form.tsx
@@ -544,8 +544,8 @@ function AutoFormObject<SchemaType extends z.ZodObject<any, any>>({
         const fieldConfigItem: FieldConfigItem = fieldConfig?.[name] ?? {};
         const zodInputProps = zodToHtmlInputProps(item);
         const isRequired =
-          zodInputProps.required ??
-          fieldConfigItem.inputProps?.required ??
+          zodInputProps.required ||
+          fieldConfigItem.inputProps?.required ||
           false;
 
         return (


### PR DESCRIPTION
Updated code for "required" property to be compared using OR operator

Fixes #31 