### PR TITLE
Make components required by default

### DIFF
--- a/src/components/ui/auto-form/utils.ts
+++ b/src/components/ui/auto-form/utils.ts
@@ -128,7 +128,9 @@ export function zodToHtmlInputProps(
 
   const typedSchema = schema as z.ZodNumber | z.ZodString;
 
-  if (!("checks" in typedSchema._def)) return {};
+  if (!("checks" in typedSchema._def)) return {
+    required: true
+  };
 
   const { checks } = typedSchema._def;
   const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {


### PR DESCRIPTION
From docs: By default, all fields are required. You can make a field optional by using the optional method.