### PR TITLE
The label and value are the same when using nativeEnum

### DIFF
--- a/src/components/ui/auto-form/fields/enum.tsx
+++ b/src/components/ui/auto-form/fields/enum.tsx
@@ -49,8 +49,8 @@ export default function AutoFormEnum({
             </SelectValue>
           </SelectTrigger>
           <SelectContent>
-            {values.map(([value, label]) => (
-              <SelectItem value={label} key={value}>
+            {values.map(([label, value]) => (
+              <SelectItem value={value} key={value}>
                 {label}
               </SelectItem>
             ))}

--- a/src/components/ui/auto-form/fields/radio-group.tsx
+++ b/src/components/ui/auto-form/fields/radio-group.tsx
@@ -22,11 +22,11 @@ export default function AutoFormRadioGroup({
   const baseValues = (getBaseSchema(zodItem) as unknown as z.ZodEnum<any>)._def
     .values;
 
-  let values: string[] = [];
+  let values: [string, string][] = [];
   if (!Array.isArray(baseValues)) {
-    values = Object.entries(baseValues).map((item) => item[0]);
+    values = Object.entries(baseValues)
   } else {
-    values = baseValues;
+    values = baseValues.map((value) => [value, value]);
   }
 
   return (
@@ -39,7 +39,7 @@ export default function AutoFormRadioGroup({
             defaultValue={field.value}
             {...fieldProps}
           >
-            {values?.map((value: any) => (
+            {values?.map(([label, value]) => (
               <FormItem
                 key={value}
                 className="mb-2 flex items-center gap-3 space-y-0"
@@ -47,7 +47,7 @@ export default function AutoFormRadioGroup({
                 <FormControl>
                   <RadioGroupItem value={value} />
                 </FormControl>
-                <FormLabel className="font-normal">{value}</FormLabel>
+                <FormLabel className="font-normal">{label}</FormLabel>
               </FormItem>
             ))}
           </RadioGroup>


### PR DESCRIPTION
To begin, I want to express my gratitude for the chance to propose enhancements to this project!

## Description:
I've observed that when utilizing `nativeEnum`, the values for `label` and `value` coincide. Furthermore, I believe it would be advantageous if `radio-group` could also accommodate the `label` and `value` format.

## Changes Made:

- Adjusted the transmission of values for `label` and `value` within the enum.
- Enhanced `radio-group` to support the `label` and `value` format similarly when using `nativeEnum`.