### PR TITLE
Expose formState for children as render prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ const formSchema = z.object({
       z.object({
         name: z.string(),
         age: z.coerce.number(),
-      })
+      }),
     )
     // Optionally set a custom label - otherwise this will be inferred from the field name
     .describe("Guests invited to the party"),
@@ -384,7 +384,7 @@ const formSchema = z.object({
       z.object({
         name: z.string(),
         age: z.coerce.number(),
-      })
+      }),
     )
     .describe("Guests invited to the party")
     .default([

--- a/src/components/ui/auto-form/index.tsx
+++ b/src/components/ui/auto-form/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { Form } from "@/components/ui/form";
 import React from "react";
-import { DefaultValues, useForm } from "react-hook-form";
+import { DefaultValues, FormState, useForm } from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
@@ -49,7 +49,9 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
   onParsedValuesChange?: (values: Partial<z.infer<SchemaType>>) => void;
   onSubmit?: (values: z.infer<SchemaType>) => void;
   fieldConfig?: FieldConfig<z.infer<SchemaType>>;
-  children?: React.ReactNode;
+  children?:
+    | React.ReactNode
+    | ((formState: FormState<z.infer<SchemaType>>) => React.ReactNode);
   className?: string;
   dependencies?: Dependency<z.infer<SchemaType>>[];
 }) {
@@ -82,6 +84,11 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
     }
   }, [valuesString]);
 
+  const renderChildren =
+    typeof children === "function"
+      ? children(form.formState as FormState<z.infer<SchemaType>>)
+      : children;
+
   return (
     <div className="w-full">
       <Form {...form}>
@@ -98,7 +105,7 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
             fieldConfig={fieldConfig}
           />
 
-          {children}
+          {renderChildren}
         </form>
       </Form>
     </div>

--- a/src/examples/Array.tsx
+++ b/src/examples/Array.tsx
@@ -17,7 +17,7 @@ const formSchema = z.object({
       z.object({
         name: z.string(),
         age: z.coerce.number(),
-      })
+      }),
     )
     .describe("Guests invited to the party"),
 });


### PR DESCRIPTION
Exposing the FormState as render props for children within the form, allowing you to view submission-state of the form and more ofc :)

e.g:

```
const RandomForm = () =>  { 
  return (
      <AutoForm ... >
        {({ isSubmitting }) => <SubmitButton pending={isSubmitting} />}
      </AutoForm>
    );
};

const SubmitButton = ({ pending }: { pending: boolean }) => {
  return (
    <Button disabled={pending} type="submit">
      {pending ? Please wait... :  Submit}
    </Button>
  );
};
```