### PR TITLE
Text area input props

### DIFF
--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -4,13 +4,15 @@ import { INPUT_COMPONENTS } from "./config";
 
 export type FieldConfigItem = {
   description?: React.ReactNode;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & {
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement> &
+  React.TextareaHTMLAttributes<HTMLTextAreaElement> &
+  {
     showLabel?: boolean;
   };
   label?: string;
   fieldType?:
-    | keyof typeof INPUT_COMPONENTS
-    | React.FC<AutoFormInputComponentProps>;
+  | keyof typeof INPUT_COMPONENTS
+  | React.FC<AutoFormInputComponentProps>;
 
   renderParent?: (props: {
     children: React.ReactNode;
@@ -20,8 +22,8 @@ export type FieldConfigItem = {
 export type FieldConfig<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
   // If SchemaType.key is an object, create a nested FieldConfig, otherwise FieldConfigItem
   [Key in keyof SchemaType]?: SchemaType[Key] extends object
-    ? FieldConfig<z.infer<SchemaType[Key]>>
-    : FieldConfigItem;
+  ? FieldConfig<z.infer<SchemaType[Key]>>
+  : FieldConfigItem;
 };
 
 export enum DependencyType {
@@ -41,9 +43,9 @@ type BaseDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
 export type ValueDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> =
   BaseDependency<SchemaType> & {
     type:
-      | DependencyType.DISABLES
-      | DependencyType.REQUIRES
-      | DependencyType.HIDES;
+    | DependencyType.DISABLES
+    | DependencyType.REQUIRES
+    | DependencyType.HIDES;
   };
 
 export type EnumValues = readonly [string, ...string[]];

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -4,14 +4,13 @@ import { INPUT_COMPONENTS } from "./config";
 
 export type FieldConfigItem = {
   description?: React.ReactNode;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement> &
-  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & {
     showLabel?: boolean;
   };
   label?: string;
   fieldType?:
-  | keyof typeof INPUT_COMPONENTS
-  | React.FC<AutoFormInputComponentProps>;
+    | keyof typeof INPUT_COMPONENTS
+    | React.FC<AutoFormInputComponentProps>;
 
   renderParent?: (props: {
     children: React.ReactNode;
@@ -21,8 +20,8 @@ export type FieldConfigItem = {
 export type FieldConfig<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
   // If SchemaType.key is an object, create a nested FieldConfig, otherwise FieldConfigItem
   [Key in keyof SchemaType]?: SchemaType[Key] extends object
-  ? FieldConfig<z.infer<SchemaType[Key]>>
-  : FieldConfigItem;
+    ? FieldConfig<z.infer<SchemaType[Key]>>
+    : FieldConfigItem;
 };
 
 export enum DependencyType {
@@ -42,9 +41,9 @@ type BaseDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
 export type ValueDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> =
   BaseDependency<SchemaType> & {
     type:
-    | DependencyType.DISABLES
-    | DependencyType.REQUIRES
-    | DependencyType.HIDES;
+      | DependencyType.DISABLES
+      | DependencyType.REQUIRES
+      | DependencyType.HIDES;
   };
 
 export type EnumValues = readonly [string, ...string[]];

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -4,13 +4,14 @@ import { INPUT_COMPONENTS } from "./config";
 
 export type FieldConfigItem = {
   description?: React.ReactNode;
-  inputProps?: React.InputHTMLAttributes<HTMLInputElement> & {
+  inputProps?: React.InputHTMLAttributes<HTMLInputElement> &
+  React.TextareaHTMLAttributes<HTMLTextAreaElement> & {
     showLabel?: boolean;
   };
   label?: string;
   fieldType?:
-    | keyof typeof INPUT_COMPONENTS
-    | React.FC<AutoFormInputComponentProps>;
+  | keyof typeof INPUT_COMPONENTS
+  | React.FC<AutoFormInputComponentProps>;
 
   renderParent?: (props: {
     children: React.ReactNode;
@@ -20,8 +21,8 @@ export type FieldConfigItem = {
 export type FieldConfig<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
   // If SchemaType.key is an object, create a nested FieldConfig, otherwise FieldConfigItem
   [Key in keyof SchemaType]?: SchemaType[Key] extends object
-    ? FieldConfig<z.infer<SchemaType[Key]>>
-    : FieldConfigItem;
+  ? FieldConfig<z.infer<SchemaType[Key]>>
+  : FieldConfigItem;
 };
 
 export enum DependencyType {
@@ -41,9 +42,9 @@ type BaseDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
 export type ValueDependency<SchemaType extends z.infer<z.ZodObject<any, any>>> =
   BaseDependency<SchemaType> & {
     type:
-      | DependencyType.DISABLES
-      | DependencyType.REQUIRES
-      | DependencyType.HIDES;
+    | DependencyType.DISABLES
+    | DependencyType.REQUIRES
+    | DependencyType.HIDES;
   };
 
 export type EnumValues = readonly [string, ...string[]];


### PR DESCRIPTION
This PR adds in types.ts FIeldConfigItem.inputProps for textarea so attributes like rows and cols can be added when fieldType is "textarea".