### PR TITLE
Added support for custom ordering of form fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import ConfirmPassword from "./examples/ConfirmPassword";
 import Controlled from "./examples/Controlled";
 import Dependencies from "./examples/Dependencies";
 import InputWithoutLabel from "./examples/InputWithoutLabel";
+import Order from "./examples/Order";
 import SubObject from "./examples/SubObject";
 
 function App() {
@@ -19,6 +20,7 @@ function App() {
         <Api />
         <Array />
         <Dependencies />
+        <Order />
       </div>
     </>
   );

--- a/src/components/ui/auto-form/fields/object.tsx
+++ b/src/components/ui/auto-form/fields/object.tsx
@@ -13,6 +13,7 @@ import {
   beautifyObjectName,
   getBaseSchema,
   getBaseType,
+  sortFieldsByOrder,
   zodToHtmlInputProps,
 } from "../utils";
 import AutoFormArray from "./array";
@@ -62,9 +63,11 @@ export default function AutoFormObject<
     return item;
   };
 
+  const sortedFieldKeys = sortFieldsByOrder(fieldConfig, Object.keys(shape));
+
   return (
     <Accordion type="multiple" className="space-y-5 border-none">
-      {Object.keys(shape).map((name) => {
+      {sortedFieldKeys.map((name) => {
         let item = shape[name] as z.ZodAny;
         item = handleIfZodNumber(item) as z.ZodAny;
         const zodBaseType = getBaseType(item);

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -17,6 +17,8 @@ export type FieldConfigItem = {
   renderParent?: (props: {
     children: React.ReactNode;
   }) => React.ReactElement | null;
+
+  order?: number;
 };
 
 export type FieldConfig<SchemaType extends z.infer<z.ZodObject<any, any>>> = {

--- a/src/components/ui/auto-form/utils.ts
+++ b/src/components/ui/auto-form/utils.ts
@@ -178,3 +178,21 @@ export function zodToHtmlInputProps(
 
   return inputProps;
 }
+
+/**
+ * Sort the fields by order.
+ * If no order is set, the field will be sorted based on the order in the schema.
+ */
+
+export function sortFieldsByOrder<SchemaType extends z.ZodObject<any, any>>(
+  fieldConfig: FieldConfig<z.infer<SchemaType>> | undefined,
+  keys: string[]
+) {
+  const sortedFields = keys.sort((a, b) => {
+    const fieldA: number = (fieldConfig?.[a]?.order as number) ?? 0;
+    const fieldB = (fieldConfig?.[b]?.order as number) ?? 0;
+    return fieldA - fieldB;
+  });
+
+  return sortedFields;
+}

--- a/src/examples/Order.tsx
+++ b/src/examples/Order.tsx
@@ -1,0 +1,83 @@
+import { Input } from "@/components/ui/input";
+import { useState } from "react";
+import * as z from "zod";
+import AutoForm, { AutoFormSubmit } from "../components/ui/auto-form";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "../components/ui/card";
+import { Label } from "@/components/ui/label";
+
+const formSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  address: z.string(),
+});
+
+function Order() {
+  const [fieldConfig, setFieldConfig] = useState<{
+    [key: string]: { order: number };
+  }>({
+    name: { order: 0 },
+    age: { order: 0 },
+    address: { order: 0 },
+  });
+
+  const handleInputChange = (field: string, value: number) => {
+    setFieldConfig((prevConfig) => ({
+      ...prevConfig,
+      [field]: { order: value },
+    }));
+  };
+
+  return (
+    <>
+      <div className="mx-auto my-6 max-w-lg">
+        <Card>
+          <CardHeader>
+            <CardTitle>AutoForm Reorder</CardTitle>
+            <CardDescription>Reorder the form fields.</CardDescription>
+          </CardHeader>
+
+          <CardContent>
+            <CardDescription className="mb-4">
+              Default order in schema: <code>name</code>, <code>age</code>,{" "}
+              <code>address</code>
+            </CardDescription>
+
+            <CardDescription className="mb-4">
+              Reorder the fields by setting the order below:
+            </CardDescription>
+
+            <div className="mb-4 flex gap-2">
+              {Object.keys(fieldConfig).map((key) => (
+                <div key={key}>
+                  <Label className="capitalize">{key}</Label>
+                  <Input
+                    type="number"
+                    onChange={(e) => {
+                      handleInputChange(key, parseInt(e.target.value));
+                    }}
+                  />
+                </div>
+              ))}
+            </div>
+
+            <AutoForm
+              formSchema={formSchema}
+              onSubmit={console.log}
+              fieldConfig={fieldConfig}
+            >
+              <AutoFormSubmit>Send now</AutoFormSubmit>
+            </AutoForm>
+          </CardContent>
+        </Card>
+      </div>
+    </>
+  );
+}
+
+export default Order;


### PR DESCRIPTION
**Problem:** 
Currently the form fields are displayed in a fixed order defined by the schema. This limits the flexibility for users who may want to customize the order of the fields (eg: when generating schema from prisma, drizzle tables). 

**Proposed Solution**
This PR adds support for custom ordering of form fields. Each field now has an optional order property that can be modified through fieldConfig.