### PR TITLE
Add ValueChangeOptions type and update AutoForm to handle value change options in callbacks.

### DIFF
--- a/src/components/ui/auto-form/index.tsx
+++ b/src/components/ui/auto-form/index.tsx
@@ -9,7 +9,12 @@ import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import AutoFormObject from "./fields/object";
-import { Dependency, FieldConfig, SubmitOptions } from "./types";
+import {
+  Dependency,
+  FieldConfig,
+  SubmitOptions,
+  ValueChangeOptions,
+} from "./types";
 import {
   ZodObjectOrWrapped,
   getDefaultValues,
@@ -45,8 +50,14 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
 }: {
   formSchema: SchemaType;
   values?: Partial<z.infer<SchemaType>>;
-  onValuesChange?: (values: Partial<z.infer<SchemaType>>) => void;
-  onParsedValuesChange?: (values: Partial<z.infer<SchemaType>>) => void;
+  onValuesChange?: (
+    values: Partial<z.infer<SchemaType>>,
+    options: ValueChangeOptions<z.infer<SchemaType>>
+  ) => void;
+  onParsedValuesChange?: (
+    values: Partial<z.infer<SchemaType>>,
+    options: ValueChangeOptions<z.infer<SchemaType>>
+  ) => void;
   onSubmit?: (
     values: z.infer<SchemaType>,
     options: SubmitOptions<z.infer<SchemaType>>
@@ -79,10 +90,14 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
 
   React.useEffect(() => {
     const subscription = form.watch((values) => {
-      onValuesChangeProp?.(values);
+      onValuesChangeProp?.(values, {
+        setError: form.setError,
+      });
       const parsedValues = formSchema.safeParse(values);
       if (parsedValues.success) {
-        onParsedValuesChange?.(parsedValues.data);
+        onParsedValuesChange?.(parsedValues.data, {
+          setError: form.setError,
+        });
       }
     });
 

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -85,3 +85,9 @@ export type AutoFormInputComponentProps = {
 export type SubmitOptions<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
   setError: UseFormSetError<SchemaType>;
 };
+
+export type ValueChangeOptions<
+  SchemaType extends z.infer<z.ZodObject<any, any>>,
+> = {
+  setError: UseFormSetError<SchemaType>;
+};


### PR DESCRIPTION
This PR enhances the `AutoForm` component by providing a `setError` function to the `onValuesChange` and `onParsedValuesChange` callbacks, allowing for more flexible error handling within form value changes.

## Key Changes

- Added a new `ValueChangeOptions` type to include the `setError` function
- Updated the `onValuesChange` and `onParsedValuesChange` prop types in `AutoForm` to include a second parameter with `setError` function
- Modified the form watch handler in `AutoForm` to pass the `setError` function to the value change callbacks
- Updated relevant type definitions and imports

This change enables developers using the `AutoForm` component to set field-specific errors programmatically during form value changes, improving the overall flexibility and error handling capabilities of the form. It aligns with the error handling capabilities provided by react-hook-form, allowing for more granular control over form validation and error display.

## Usage Example
```tsx
<AutoForm
    onValuesChange={(values, { setError }) => {
        // Handle form value changes
        // Use setError to set field-specific errors if needed
        if (values.fieldName === 'invalid') {
            setError("fieldName", { type: "custom", message: "Invalid value" });
        }
    }}
    onParsedValuesChange={(parsedValues, { setError }) => {
        // Handle parsed form value changes
        // Use setError for more complex validation scenarios
    }}
/>
```