### PR TITLE
Refactor AutoForm callbacks to include form object, remove SubmitOptions type

### DIFF
--- a/src/components/ui/auto-form/index.tsx
+++ b/src/components/ui/auto-form/index.tsx
@@ -1,7 +1,12 @@
 "use client";
 import { Form } from "@/components/ui/form";
 import React from "react";
-import { DefaultValues, FormState, useForm } from "react-hook-form";
+import {
+  DefaultValues,
+  FormState,
+  useForm,
+  UseFormReturn,
+} from "react-hook-form";
 import { z } from "zod";
 
 import { Button } from "@/components/ui/button";
@@ -9,16 +14,11 @@ import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import AutoFormObject from "./fields/object";
+import { Dependency, FieldConfig } from "./types";
 import {
-  Dependency,
-  FieldConfig,
-  SubmitOptions,
-  ValueChangeOptions,
-} from "./types";
-import {
-  ZodObjectOrWrapped,
   getDefaultValues,
   getObjectFormSchema,
+  ZodObjectOrWrapped,
 } from "./utils";
 
 export function AutoFormSubmit({
@@ -52,15 +52,15 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
   values?: Partial<z.infer<SchemaType>>;
   onValuesChange?: (
     values: Partial<z.infer<SchemaType>>,
-    options: ValueChangeOptions<z.infer<SchemaType>>
+    form: UseFormReturn<z.infer<SchemaType>>
   ) => void;
   onParsedValuesChange?: (
     values: Partial<z.infer<SchemaType>>,
-    options: ValueChangeOptions<z.infer<SchemaType>>
+    form: UseFormReturn<z.infer<SchemaType>>
   ) => void;
   onSubmit?: (
     values: z.infer<SchemaType>,
-    options: SubmitOptions<z.infer<SchemaType>>
+    form: UseFormReturn<z.infer<SchemaType>>
   ) => void;
   fieldConfig?: FieldConfig<z.infer<SchemaType>>;
   children?:
@@ -82,22 +82,16 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
   function onSubmit(values: z.infer<typeof formSchema>) {
     const parsedValues = formSchema.safeParse(values);
     if (parsedValues.success) {
-      onSubmitProp?.(parsedValues.data, {
-        setError: form.setError,
-      });
+      onSubmitProp?.(parsedValues.data, form);
     }
   }
 
   React.useEffect(() => {
     const subscription = form.watch((values) => {
-      onValuesChangeProp?.(values, {
-        setError: form.setError,
-      });
+      onValuesChangeProp?.(values, form);
       const parsedValues = formSchema.safeParse(values);
       if (parsedValues.success) {
-        onParsedValuesChange?.(parsedValues.data, {
-          setError: form.setError,
-        });
+        onParsedValuesChange?.(parsedValues.data, form);
       }
     });
 

--- a/src/components/ui/auto-form/index.tsx
+++ b/src/components/ui/auto-form/index.tsx
@@ -9,7 +9,12 @@ import { cn } from "@/lib/utils";
 import { zodResolver } from "@hookform/resolvers/zod";
 
 import AutoFormObject from "./fields/object";
-import { Dependency, FieldConfig, SubmitOptions } from "./types";
+import {
+  Dependency,
+  FieldConfig,
+  SubmitOptions,
+  ValueChangeOptions,
+} from "./types";
 import {
   ZodObjectOrWrapped,
   getDefaultValues,
@@ -45,8 +50,14 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
 }: {
   formSchema: SchemaType;
   values?: Partial<z.infer<SchemaType>>;
-  onValuesChange?: (values: Partial<z.infer<SchemaType>>) => void;
-  onParsedValuesChange?: (values: Partial<z.infer<SchemaType>>) => void;
+  onValuesChange?: (
+    values: Partial<z.infer<SchemaType>>,
+    options: ValueChangeOptions<z.infer<SchemaType>>
+  ) => void;
+  onParsedValuesChange?: (
+    values: Partial<z.infer<SchemaType>>,
+    options: ValueChangeOptions<z.infer<SchemaType>>
+  ) => void;
   onSubmit?: (
     values: z.infer<SchemaType>,
     options: SubmitOptions<z.infer<SchemaType>>
@@ -79,10 +90,14 @@ function AutoForm<SchemaType extends ZodObjectOrWrapped>({
 
   React.useEffect(() => {
     const subscription = form.watch((values) => {
-      onValuesChangeProp?.(values);
+      onValuesChangeProp?.(values, {
+        setError: form.setError,
+      });
       const parsedValues = formSchema.safeParse(values);
       if (parsedValues.success) {
-        onParsedValuesChange?.(parsedValues.data);
+        onParsedValuesChange?.(parsedValues.data, {
+          setError: form.setError,
+        });
       }
     });
 

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -1,8 +1,4 @@
-import {
-  ControllerRenderProps,
-  FieldValues,
-  UseFormSetError,
-} from "react-hook-form";
+import { ControllerRenderProps, FieldValues } from "react-hook-form";
 import * as z from "zod";
 import { INPUT_COMPONENTS } from "./config";
 
@@ -80,14 +76,4 @@ export type AutoFormInputComponentProps = {
   fieldProps: any;
   zodItem: z.ZodAny;
   className?: string;
-};
-
-export type SubmitOptions<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
-  setError: UseFormSetError<SchemaType>;
-};
-
-export type ValueChangeOptions<
-  SchemaType extends z.infer<z.ZodObject<any, any>>,
-> = {
-  setError: UseFormSetError<SchemaType>;
 };

--- a/src/components/ui/auto-form/types.ts
+++ b/src/components/ui/auto-form/types.ts
@@ -85,3 +85,9 @@ export type AutoFormInputComponentProps = {
 export type SubmitOptions<SchemaType extends z.infer<z.ZodObject<any, any>>> = {
   setError: UseFormSetError<SchemaType>;
 };
+
+export type ValueChangeOptions<
+  SchemaType extends z.infer<z.ZodObject<any, any>>,
+> = {
+  setError: UseFormSetError<SchemaType>;
+};


### PR DESCRIPTION
This PR refactors the AutoForm component to include the form object in callback functions and removes the SubmitOptions type. The changes improve the flexibility and functionality of the AutoForm component.

### Changes
- Updated onValuesChange, onParsedValuesChange, and onSubmit callbacks to include the UseFormReturn object as a parameter.
- Removed the SubmitOptions type and its usage in the onSubmit function.
- Adjusted the useEffect hook to pass the form object to callbacks.
- Removed unused imports from the types file.

These changes provide more control to the users of the AutoForm component by giving them access to the full form object in the callback functions. This allows for more advanced form manipulation and validation scenarios.