### PR TITLE
Fix BooleanField to use value

### DIFF
--- a/packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx
+++ b/packages/shadcn/src/components/ui/autoform/components/BooleanField.tsx
@@ -8,6 +8,7 @@ export const BooleanField: React.FC<AutoFormFieldProps> = ({
   label,
   id,
   inputProps,
+  value
 }) => (
   <div className="flex items-center space-x-2">
     <Checkbox
@@ -22,7 +23,7 @@ export const BooleanField: React.FC<AutoFormFieldProps> = ({
         };
         inputProps.onChange(event);
       }}
-      checked={inputProps.value}
+      checked={value}
     />
     <Label htmlFor={id}>
       {label}


### PR DESCRIPTION
Fix BooleanField to use value instead of inputProps.value for checkbox checked