### PR TITLE
Fixed import path in Mantine integration

### DIFF
--- a/packages/mantine/src/types.ts
+++ b/packages/mantine/src/types.ts
@@ -1,4 +1,4 @@
-import { ExtendableAutoFormProps } from "@autoform/react/src/types";
+import { ExtendableAutoFormProps } from "@autoform/react";
 import { MantineProvider } from "@mantine/core";
 import { FieldValues } from "react-hook-form";
 


### PR DESCRIPTION
The base Form props were missing in the Mantine AutoForm as the import was specified incorrectly.