### PR TITLE
fix: change to `peerDependencies`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19783,7 +19783,7 @@
     },
     "packages/core": {
       "name": "@autoform/core",
-      "version": "2.0.0",
+      "version": "2.1.0",
       "devDependencies": {
         "@autoform/eslint-config": "*",
         "@autoform/typescript-config": "*",
@@ -20060,8 +20060,7 @@
         "@autoform/yup": "*",
         "@autoform/zod": "*",
         "@hookform/resolvers": "^3.9.0",
-        "react": "^18.2.0",
-        "react-hook-form": "^7.53.0"
+        "react": "^18.2.0"
       },
       "devDependencies": {
         "@autoform/eslint-config": "*",
@@ -20074,6 +20073,9 @@
         "eslint": "^8.57.0",
         "tsup": "^8.3.0",
         "typescript": "^5.3.3"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.53.0"
       }
     },
     "packages/shadcn": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20071,6 +20071,7 @@
         "@types/react": "^18.2.61",
         "@types/react-dom": "^18.2.19",
         "eslint": "^8.57.0",
+        "react-hook-form": "^7.53.0",
         "tsup": "^8.3.0",
         "typescript": "^5.3.3"
       },
@@ -20099,7 +20100,6 @@
         "lucide-react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
         "react-day-picker": "^8.10.1",
-        "react-hook-form": "^7.53.0",
         "tailwind-merge": "^2.3.0",
         "tailwindcss-animate": "^1.0.7",
         "tsup": "^8.3.0",
@@ -20116,11 +20116,13 @@
         "eslint": "^8.57.0",
         "postcss": "^8",
         "postcss-load-config": "^6",
+        "react-hook-form": "^7.53.0",
         "tailwindcss": "*",
         "typescript": "^5.3.3"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+        "react-hook-form": "^7.53.0"
       }
     },
     "packages/ts": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -23,7 +23,8 @@
     "@types/react-dom": "^18.2.19",
     "eslint": "^8.57.0",
     "tsup": "^8.3.0",
-    "typescript": "^5.3.3"
+    "typescript": "^5.3.3",
+    "react-hook-form": "^7.53.0"
   },
   "dependencies": {
     "@autoform/core": "*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -30,7 +30,9 @@
     "@autoform/zod": "*",
     "@autoform/yup": "*",
     "@hookform/resolvers": "^3.9.0",
-    "react": "^18.2.0",
+    "react": "^18.2.0"
+  },
+  "peerDependencies": {
     "react-hook-form": "^7.53.0"
   }
 }

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -31,6 +31,7 @@
     "@types/react-dom": "^18.2.19",
     "autoprefixer": "^10",
     "eslint": "^8.57.0",
+    "react-hook-form": "^7.53.0",
     "postcss": "^8",
     "postcss-load-config": "^6",
     "tailwindcss": "*",
@@ -54,13 +55,13 @@
     "lucide-react": "*",
     "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
     "react-day-picker": "^8.10.1",
-    "react-hook-form": "^7.53.0",
     "tailwind-merge": "^2.3.0",
     "tailwindcss-animate": "^1.0.7",
     "tsup": "^8.3.0",
     "zod": "^3.23.8"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
+    "react-hook-form": "^7.53.0"
   }
 }


### PR DESCRIPTION
I want to call `react-hook-form` but  it will use dual package if don't change to peer dependency