### PR TITLE
fix: 🐛 fix SelectField of Shadcn UI with zod

### DIFF
--- a/apps/web/cypress/component/autoform/shadcn-zod/enums.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/enums.cy.tsx
@@ -1,0 +1,68 @@
+import React from "react";
+import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
+import { ZodProvider } from "@autoform/zod";
+import { z } from "zod";
+import { TestWrapper } from "./utils";
+
+describe("AutoForm Enums Tests", () => {
+  const arraySchema = z.object({
+    gender: z.enum(["male", "female"]),
+  });
+  const schemaProvider = new ZodProvider(arraySchema);
+
+  const arraySchemaWithDefault = z.object({
+    gender: z.enum(["male", "female"]).default("male"),
+  });
+  const schemaProviderWithDefault = new ZodProvider(arraySchemaWithDefault);
+
+  it("renders enums fields correctly", () => {
+    cy.mount(
+      <TestWrapper>
+        <AutoForm
+          schema={schemaProvider}
+          onSubmit={cy.stub().as("onSubmit")}
+          withSubmit
+        />
+      </TestWrapper>,
+    );
+
+    // Check if select trigger exists
+    cy.get('[role="combobox"]').should("exist");
+
+    // Open the select dropdown
+    cy.get('[role="combobox"]').click();
+
+    // Verify options are rendered correctly
+    cy.get('[role="option"]').should("have.length", 2);
+    cy.get('[role="option"]').eq(0).should("have.text", "male");
+    cy.get('[role="option"]').eq(1).should("have.text", "female");
+
+    // Test form submission with selected value
+    cy.get('[role="option"]').contains("female").click();
+    cy.get("form").submit();
+    cy.get("@onSubmit").should("have.been.calledWith", {
+      gender: "female",
+    });
+  });
+
+  it("handles default values for enums correctly", () => {
+    cy.mount(
+      <TestWrapper>
+        <AutoForm
+          schema={schemaProviderWithDefault}
+          onSubmit={cy.stub().as("onSubmit")}
+          withSubmit
+        />
+      </TestWrapper>,
+    );
+
+    // Verify default value is selected
+    cy.get('[role="combobox"]').should("contain.text", "male");
+
+    // Submit form without changes to verify default value
+    cy.get("form").submit();
+    cy.get("@onSubmit").should("have.been.calledWith", {
+      gender: "male",
+    });
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "apps/docs": {
-      "version": "1.1.0",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "@autoform/core": "*",
@@ -354,7 +354,7 @@
       }
     },
     "apps/web": {
-      "version": "1.1.0",
+      "version": "2.0.0",
       "dependencies": {
         "@autoform/ant": "*",
         "@autoform/mantine": "*",
@@ -20878,7 +20878,7 @@
     },
     "packages/ant": {
       "name": "@autoform/ant",
-      "version": "0.0.1",
+      "version": "1.0.0",
       "dependencies": {
         "@ant-design/icons": "^5.5.2",
         "@autoform/core": "*",
@@ -21014,7 +21014,7 @@
     },
     "packages/mantine": {
       "name": "@autoform/mantine",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@autoform/core": "*",
         "@autoform/react": "*",
@@ -21255,7 +21255,7 @@
     },
     "packages/react": {
       "name": "@autoform/react",
-      "version": "2.2.0",
+      "version": "3.0.0",
       "dependencies": {
         "@autoform/core": "*",
         "@autoform/yup": "*",

--- a/packages/shadcn/src/components/ui/autoform/components/SelectField.tsx
+++ b/packages/shadcn/src/components/ui/autoform/components/SelectField.tsx
@@ -17,7 +17,19 @@ export const SelectField: React.FC<AutoFormFieldProps> = ({
   const { key, ...props } = inputProps;
 
   return (
-    <Select {...props}>
+    <Select
+      {...props}
+      onValueChange={(value) => {
+        const syntheticEvent = {
+          target: {
+            value,
+            name: field.key,
+          },
+        } as React.ChangeEvent<HTMLInputElement>;
+        props.onChange(syntheticEvent);
+      }}
+      defaultValue={field.default}
+    >
       <SelectTrigger id={id} className={error ? "border-destructive" : ""}>
         <SelectValue placeholder="Select an option" />
       </SelectTrigger>


### PR DESCRIPTION
**Bug description**
- Select field give validation error even if value is selected
- Default value for select field from zod schema not pre selected

**Type of changes**
- Fixed SelectField `packages/shadcn/src/components/ui/autoform/components/SelectField.tsx`
- Added test case for SelectField using zod `z.enum()` schema type with default value (#150) 

**Screenshots**
<img width="1728" alt="image" src="https://github.com/user-attachments/assets/d889f998-08ad-4f4b-8c61-64118d90707f" />
