### PR TITLE
feat(zod/v4-mini): add v4-mini support alongside v4 using core module

### DIFF
--- a/apps/web/components/Ant.tsx
+++ b/apps/web/components/Ant.tsx
@@ -1,11 +1,11 @@
 "use client";
 import { AutoForm } from "@autoform/ant";
-import { joiSchemaProvider } from "./utils";
+import { zodSchemaProvider } from "./utils";
 
 const Ant = () => {
   return (
     <AutoForm
-      schema={joiSchemaProvider}
+      schema={zodSchemaProvider}
       onSubmit={(data) => {
         console.log(JSON.stringify(data, null, 2));
       }}

--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -250,14 +250,16 @@ const zodFormSchema4 = z4.object({
     .describe("How many marshmallows fit in your mouth?"),
   // Native enum example
   sports: z4.enum(Sports).describe("What is your favourite sport?"),
-  guests: z4
-    .array(
-      z4.object({
-        name: z4.string(),
-        age: z4.coerce.number().optional(),
-        location: z4.object({
-          city: z4.string(),
-          country: z4.string().optional(),
+  guests: z4.array(
+    z4.object({
+      name: z4.string(),
+      age: z4.coerce.number().optional(),
+      location: z4.object({
+        city: z4.string(),
+        country: z4.string().optional(),
+        test: z4.object({
+          name: z4.string(),
+          age: z4.coerce.number(),
           test: z4.object({
             name: z4.string(),
             age: z4.coerce.number(),
@@ -267,18 +269,13 @@ const zodFormSchema4 = z4.object({
               test: z4.object({
                 name: z4.string(),
                 age: z4.coerce.number(),
-                test: z4.object({
-                  name: z4.string(),
-                  age: z4.coerce.number(),
-                }),
               }),
             }),
           }),
         }),
-      })
-    )
-    .min(1, "minimum one guest is required")
-    .optional(),
+      }),
+    })
+  ),
 });
 
 // zod mini
@@ -311,7 +308,7 @@ const zodFormSchema4mini = zm.object({
     .register(
       ...config({
         // Changed from superRefine to register
-        description: "Always use a <b>secure password</b>!",
+        description: "Always use a secure password!",
         inputProps: {
           type: "password",
         },
@@ -348,19 +345,19 @@ const zodFormSchema4mini = zm.object({
   Birthdate: zm.optional(zm.date()),
   array: zm.array(
     zm.object({
-      super: zm.string(),
+      mini: zm.string(),
       age: zm.number(),
       isStudent: zm._default(zm.boolean(), true),
     })
   ),
   object: zm.object({
-    super: zm.optional(zm.string()),
+    mini: zm.optional(zm.string()),
     age: zm.optional(zm.number()),
     isStudent: zm.optional(zm.boolean()),
   }),
 });
 
-export const zodSchemaProvider = new ZodProvider(zodFormSchema);
+export const zodSchemaProvider = new ZodProvider4(zodFormSchema4mini);
 
 const yupFormSchema = object({
   name: string().required().label("Your Name").default("John Doe"),

--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -3,8 +3,14 @@ import {
   FieldWrapperProps,
   buildZodFieldConfig,
 } from "@autoform/react";
-import * as z from "zod";
 import Joi from "joi";
+import * as z from "zod";
+import * as z4 from "zod/v4";
+import * as zm from "zod/v4-mini";
+import {
+  ZodProvider as ZodProvider4,
+  fieldConfig as config,
+} from "@autoform/zod/v4";
 import { object, string, number, date, InferType, array, mixed } from "yup";
 import { ZodProvider } from "@autoform/zod";
 import { YupProvider, fieldConfig as yupFieldConfig } from "@autoform/yup";
@@ -163,6 +169,195 @@ const zodFormSchema = z.object({
   //   }),
   // }),
   // obj
+});
+
+const zodFormSchema4 = z4.object({
+  username: z4
+    .string({
+      error: "Username is required.",
+    })
+    .min(2, {
+      message: "Username must be at least 2 characters.",
+    })
+    .register(
+      ...config({
+        description: "You cannot change this later.",
+      })
+    ),
+  password: z4
+    .string({
+      error: "Password is required.",
+    })
+    .min(8, {
+      message: "Password must be at least 8 characters.",
+    })
+    .default("this ia s good pass")
+    .describe("Your secure password")
+    .register(
+      ...config({
+        description: (
+          <>
+            Always use a <b>secure password</b>!
+          </>
+        ),
+        inputProps: {
+          type: "password",
+        },
+      })
+    ),
+  favouriteNumber: z4.coerce
+    .number({
+      error: "Favourite number must be a number.",
+    })
+    .min(1, {
+      message: "Favourite number must be at least 1.",
+    })
+    .max(10, {
+      message: "Favourite number must be at most 10.",
+    })
+    .default(9)
+    .optional(),
+  acceptTerms: z4
+    .boolean()
+    .default(true)
+    .describe("Accept terms and conditions.")
+    .refine((value) => value, {
+      message: "You must accept the terms and conditions.",
+    }),
+  sendMeMails: z4
+    .boolean()
+    .optional()
+    .default(false)
+    .register(
+      ...config({
+        fieldWrapper: (props: FieldWrapperProps) => {
+          return (
+            <>
+              {props.children}
+              <p className="text-muted-foreground text-sm">
+                Don't worry, we only send important emails!
+              </p>
+            </>
+          );
+        },
+      })
+    ),
+  birthday: z4.coerce.date({ message: "aaa" }).optional(),
+  color: z4.enum(["red", "green", "blue"]).default("red").optional(),
+  // Another enum example
+  marshmallows: z4
+    .enum(["not many", "a few", "a lot", "too many"])
+    .describe("How many marshmallows fit in your mouth?"),
+  // Native enum example
+  sports: z4.enum(Sports).describe("What is your favourite sport?"),
+  guests: z4
+    .array(
+      z4.object({
+        name: z4.string(),
+        age: z4.coerce.number().optional(),
+        location: z4.object({
+          city: z4.string(),
+          country: z4.string().optional(),
+          test: z4.object({
+            name: z4.string(),
+            age: z4.coerce.number(),
+            test: z4.object({
+              name: z4.string(),
+              age: z4.coerce.number(),
+              test: z4.object({
+                name: z4.string(),
+                age: z4.coerce.number(),
+                test: z4.object({
+                  name: z4.string(),
+                  age: z4.coerce.number(),
+                }),
+              }),
+            }),
+          }),
+        }),
+      })
+    )
+    .min(1, "minimum one guest is required")
+    .optional(),
+});
+
+// zod mini
+const zodFormSchema4mini = zm.object({
+  username: zm
+    .string({
+      error: "Username is required.",
+    })
+    .check(
+      zm.minLength(2, {
+        message: "Username must be at least 2 characters.",
+      })
+    )
+    .register(
+      ...config({
+        // Changed from superRefine to register
+        description: "You cannot change this later.",
+      })
+    ),
+
+  password: zm
+    .string({
+      error: "Password is required.",
+    })
+    .check(
+      zm.minLength(8, {
+        message: "Password must be at least 8 characters.",
+      })
+    )
+    .register(
+      ...config({
+        // Changed from superRefine to register
+        description: "Always use a <b>secure password</b>!",
+        inputProps: {
+          type: "password",
+        },
+      })
+    ),
+
+  sendMeMails: zm.optional(zm.boolean()).register(
+    ...config({
+      // Changed from superRefine to register
+      fieldWrapper: (props: FieldWrapperProps) => (
+        <>
+          {props.children}
+          <p className="text-muted-foreground text-sm">
+            Don't worry, we only send important emails!
+          </p>
+        </>
+      ),
+    })
+  ),
+
+  favouriteNumber: zm.optional(zm._default(zm.number(), 4)).register(
+    ...config({
+      description: "Enter your favourite number",
+      label: "Favourite Number !!!",
+    })
+  ),
+
+  favouriteSport: zm.enum(["red", "green", "blue"]).register(
+    ...config({
+      description: "Your favourite sport",
+    })
+  ),
+
+  Birthdate: zm.optional(zm.date()),
+  array: zm.array(
+    zm.object({
+      super: zm.string(),
+      age: zm.number(),
+      isStudent: zm._default(zm.boolean(), true),
+    })
+  ),
+  object: zm.object({
+    super: zm.optional(zm.string()),
+    age: zm.optional(zm.number()),
+    isStudent: zm.optional(zm.boolean()),
+  }),
 });
 
 export const zodSchemaProvider = new ZodProvider(zodFormSchema);

--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -219,8 +219,8 @@ const zodFormSchema4 = z4.object({
     .optional(),
   acceptTerms: z4
     .boolean()
-    .default(true)
     .describe("Accept terms and conditions.")
+    .default(true)
     .refine((value) => value, {
       message: "You must accept the terms and conditions.",
     }),

--- a/apps/web/cypress/component/autoform/all.cy.tsx
+++ b/apps/web/cypress/component/autoform/all.cy.tsx
@@ -1,5 +1,6 @@
 import "./ant-joi/all.cy";
 import "./ant-zod/all.cy";
+import "./ant-zod-v4-mini/all.cy";
 import "./chakra-zod/all.cy";
 import "./mantine-zod/all.cy";
 import "./mui-yup/all.cy";

--- a/apps/web/cypress/component/autoform/ant-zod-v4-mini/all.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod-v4-mini/all.cy.tsx
@@ -1,0 +1,2 @@
+import "./basics.cy";
+import "./validation.cy";

--- a/apps/web/cypress/component/autoform/ant-zod-v4-mini/basics.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod-v4-mini/basics.cy.tsx
@@ -1,0 +1,69 @@
+import React from "react";
+import { AutoForm } from "@autoform/ant";
+import { ZodProvider } from "@autoform/zod/v4";
+import { z } from "zod/v4-mini";
+
+describe("AutoForm Basic Tests", () => {
+  const basicSchema = z.object({
+    name: z.string().check(
+      z.minLength(2)
+      // Zod Mini does not support custom error messages in .check() refinements
+    ),
+    age: z.coerce.number().check(
+      z.gte(18)
+      // Custom error messages are not supported in .check()
+    ),
+    email: z.string(), // Zod Mini does not provide a built-in .email() check
+    website: z.optional(z.string()), // .url() is not available in Zod Mini
+    birthdate: z.coerce.date(),
+    isStudent: z.boolean(),
+  });
+
+  const schemaProvider = new ZodProvider(basicSchema);
+
+  it("renders all field types correctly", () => {
+    cy.mount(
+      <AutoForm
+        schema={schemaProvider}
+        onSubmit={cy.stub().as("onSubmit")}
+        withSubmit
+      />
+    );
+
+    cy.get('input[name="name"]').should("exist");
+    cy.get('input[name="age"]').should("have.class", "ant-input-number-input");
+    cy.get('input[name="email"]').should("exist");
+    cy.get('input[name="website"]').should("exist");
+    cy.get('input[name="birthdate"]');
+    cy.get('input[name="isStudent"]').should(
+      "have.class",
+      "ant-checkbox-input"
+    );
+  });
+
+  it("submits form with correct data types", () => {
+    const onSubmit = cy.stub().as("onSubmit");
+    cy.mount(
+      <AutoForm schema={schemaProvider} onSubmit={onSubmit} withSubmit />
+    );
+
+    cy.get('input[name="name"]').type("John Doe");
+    cy.get('input[name="age"]').type("25");
+    cy.get('input[name="email"]').type("john@example.com");
+    cy.get('input[name="website"]').type("https://example.com");
+    cy.get('input[name="birthdate"]').clear().type("1990-01-01");
+    cy.get('input[name="isStudent"]').check();
+
+    cy.get('button[type="submit"]').click();
+
+    cy.get("@onSubmit").should("have.been.calledOnce");
+    cy.get("@onSubmit").should("have.been.calledWith", {
+      name: "John Doe",
+      age: 25,
+      email: "john@example.com",
+      website: "https://example.com",
+      birthdate: new Date("1990-01-01"),
+      isStudent: true,
+    });
+  });
+});

--- a/apps/web/cypress/component/autoform/ant-zod-v4-mini/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod-v4-mini/validation.cy.tsx
@@ -1,0 +1,57 @@
+import React from "react";
+import { AutoForm } from "@autoform/ant";
+import { ZodProvider } from "@autoform/zod/v4";
+import { z } from "zod/v4-mini";
+
+describe("AutoForm Validation Tests", () => {
+  const validationSchema = z.object({
+    username: z.string().check(z.minLength(3)),
+    password: z.string().check(z.minLength(8)),
+    email: z.string(),
+  });
+  const schemaProvider = new ZodProvider(validationSchema);
+
+  it("shows validation errors when submitting invalid data", () => {
+    cy.mount(
+      <AutoForm
+        schema={schemaProvider}
+        onSubmit={cy.stub().as("onSubmit")}
+        withSubmit
+      />
+    );
+
+    cy.get('input[name="username"]').type("ab");
+    cy.get('input[name="password"]').type("1234567");
+    cy.get('input[name="email"]').type("invalid");
+
+    cy.get('button[type="submit"]').click();
+
+    cy.contains("Invalid input").should("be.visible");
+    cy.contains("Invalid input").should("be.visible");
+    cy.contains("Invalid input").should("be.visible");
+
+    cy.get("@onSubmit").should("not.have.been.called");
+  });
+
+  it("does not show errors for valid data", () => {
+    cy.mount(
+      <AutoForm
+        schema={schemaProvider}
+        onSubmit={cy.stub().as("onSubmit")}
+        withSubmit
+      />
+    );
+
+    cy.get('input[name="username"]').type("johndoe");
+    cy.get('input[name="password"]').type("password123");
+    cy.get('input[name="email"]').type("john@example.com");
+
+    cy.get('button[type="submit"]').click();
+
+    cy.contains("Username must be at least 3 characters").should("not.exist");
+    cy.contains("Password must be at least 8 characters").should("not.exist");
+    cy.contains("Invalid email address").should("not.exist");
+
+    cy.get("@onSubmit").should("have.been.calledOnce");
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "apps/docs": {
-      "version": "2.1.0",
+      "version": "2.2.0",
       "license": "MIT",
       "dependencies": {
         "@autoform/core": "*",
@@ -22465,7 +22465,7 @@
     },
     "packages/zod": {
       "name": "@autoform/zod",
-      "version": "2.2.0",
+      "version": "3.1.0",
       "dependencies": {
         "@autoform/core": "*"
       },

--- a/packages/zod/src/v4/default-values.ts
+++ b/packages/zod/src/v4/default-values.ts
@@ -1,15 +1,17 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/core";
 
-export function getDefaultValueInZodStack(schema: z.ZodType): any {
-  if (schema instanceof z.ZodDefault) {
-    return schema.def.defaultValue;
+export function getDefaultValueInZodStack(schema: z.$ZodType): any {
+  if (schema instanceof z.$ZodDefault) {
+    return schema._zod.def.defaultValue;
   }
-
+  else if('innerType' in schema._zod.def) {
+    return getDefaultValueInZodStack(schema._zod.def.innerType as z.$ZodType)
+  }
   return undefined;
 }
 
-export function getDefaultValues(schema: z.ZodObject): Record<string, any> {
-  const shape = schema.shape;
+export function getDefaultValues(schema: z.$ZodObject): Record<string, any> {
+  const shape = schema._zod.def.shape;
 
   const defaultValues: Record<string, any> = {};
 

--- a/packages/zod/src/v4/field-config.ts
+++ b/packages/zod/src/v4/field-config.ts
@@ -1,4 +1,4 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/core";
 import { FieldConfig } from "@autoform/core";
 
 interface FieldConfigMeta {
@@ -21,13 +21,13 @@ export function fieldConfig<
     FieldTypes,
     FieldWrapper,
     CustomData
-  >,
+  >
 ): FieldConfigReturn {
   return [fieldConfigRegistry, { fieldConfig: config }];
 }
 
 export function getFieldConfigInZodStack(
-  schema: z.ZodType,
+  schema: z.$ZodType
 ): FieldConfig | undefined {
   return fieldConfigRegistry.get(schema)?.fieldConfig;
 }

--- a/packages/zod/src/v4/field-type-inference.ts
+++ b/packages/zod/src/v4/field-type-inference.ts
@@ -1,21 +1,21 @@
 import { FieldConfig } from "@autoform/core";
-import { z } from "zod/v4";
+import * as z from "zod/v4/core";
 
 export function inferFieldType(
-  schema: z.ZodTypeAny,
-  fieldConfig?: FieldConfig,
+  schema: z.$ZodType,
+  fieldConfig?: FieldConfig
 ): string {
   if (fieldConfig?.fieldType) {
     return fieldConfig.fieldType;
   }
 
-  if (schema instanceof z.ZodObject) return "object";
-  if (schema instanceof z.ZodString) return "string";
-  if (schema instanceof z.ZodNumber) return "number";
-  if (schema instanceof z.ZodBoolean) return "boolean";
-  if (schema instanceof z.ZodDate) return "date";
-  if (schema instanceof z.ZodEnum) return "select";
-  if (schema instanceof z.ZodArray) return "array";
+  if (schema instanceof z.$ZodObject) return "object";
+  if (schema instanceof z.$ZodString) return "string";
+  if (schema instanceof z.$ZodNumber) return "number";
+  if (schema instanceof z.$ZodBoolean) return "boolean";
+  if (schema instanceof z.$ZodDate) return "date";
+  if (schema instanceof z.$ZodEnum) return "select";
+  if (schema instanceof z.$ZodArray) return "array";
 
   return "string"; // Default to string for unknown types
 }

--- a/packages/zod/src/v4/provider.ts
+++ b/packages/zod/src/v4/provider.ts
@@ -1,9 +1,9 @@
-import { z } from "zod/v4";
-import { SchemaProvider, ParsedSchema, SchemaValidation } from "@autoform/core";
+import * as z from "zod/v4/core";
 import { getDefaultValues } from "./default-values";
 import { parseSchema } from "./schema-parser";
+import { SchemaProvider, ParsedSchema, SchemaValidation } from "@autoform/core";
 
-export class ZodProvider<T extends z.ZodObject>
+export class ZodProvider<T extends z.$ZodObject>
   implements SchemaProvider<z.infer<T>>
 {
   /**
@@ -23,10 +23,10 @@ export class ZodProvider<T extends z.ZodObject>
 
   validateSchema(values: z.infer<T>): SchemaValidation {
     try {
-      const data = this.schema.parse(values);
+      const data = z.parse(this.schema, values);
       return { success: true, data } as const;
     } catch (error) {
-      if (error instanceof z.ZodError) {
+      if (error instanceof z.$ZodError) {
         return {
           success: false,
           errors: error.issues.map((error) => ({

--- a/packages/zod/src/v4/schema-parser.ts
+++ b/packages/zod/src/v4/schema-parser.ts
@@ -1,17 +1,17 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/core";
 import { inferFieldType } from "./field-type-inference";
 import { getDefaultValueInZodStack } from "./default-values";
 import { getFieldConfigInZodStack } from "./field-config";
 import { ParsedField, ParsedSchema } from "@autoform/core";
 
-function parseField(key: string, schema: z.ZodType): ParsedField {
+function parseField(key: string, schema: z.$ZodType): ParsedField {
   const baseSchema = getBaseSchema(schema);
   const fieldConfig = getFieldConfigInZodStack(schema);
   const type = inferFieldType(baseSchema, fieldConfig);
   const defaultValue = getDefaultValueInZodStack(schema);
 
   // Enums
-  const options = (baseSchema as z.ZodEnum).def.entries;
+  const options = (baseSchema as z.$ZodEnum)._zod.def.entries;
   let optionValues: [string, string][] = [];
   if (options) {
     if (!Array.isArray(options)) {
@@ -23,43 +23,57 @@ function parseField(key: string, schema: z.ZodType): ParsedField {
 
   // Arrays and objects
   let subSchema: ParsedField[] = [];
-  if (baseSchema instanceof z.ZodObject) {
-    subSchema = Object.entries(baseSchema.shape).map(([key, field]) =>
-      parseField(key, field as z.ZodTypeAny),
+  if (baseSchema instanceof z.$ZodObject) {
+    subSchema = Object.entries(baseSchema._zod.def.shape).map(([key, field]) =>
+      parseField(key, field as z.$ZodType)
     );
   }
-  if (baseSchema instanceof z.ZodArray) {
-    subSchema = [parseField("0", baseSchema.def.element as z.ZodType)];
+  if (baseSchema instanceof z.$ZodArray) {
+    subSchema = [parseField("0", baseSchema._zod.def.element as z.$ZodType)];
   }
 
   return {
     key,
     type,
-    required: !schema.safeParse(undefined).success,
+    required: !isOptional(schema),
     default: defaultValue,
-    description: schema.description,
+    description: z.globalRegistry.get(schema)?.description,
     fieldConfig,
     options: optionValues,
     schema: subSchema,
   };
 }
 
-export function parseSchema(schema: z.ZodObject): ParsedSchema {
-  const shape = schema.shape;
+export function parseSchema(schema: z.$ZodObject): ParsedSchema {
+  const shape = schema._zod.def.shape;
 
   const fields: ParsedField[] = Object.entries(shape).map(([key, field]) =>
-    parseField(key, field as z.ZodTypeAny),
+    parseField(key, field as z.$ZodType)
   );
 
   return { fields };
 }
 
-function getBaseSchema<SchemaType extends z.ZodType>(
-  schema: SchemaType | z.ZodDefault<SchemaType>,
+function getBaseSchema<SchemaType extends z.$ZodType>(
+  schema: SchemaType | z.$ZodDefault<SchemaType>
 ): SchemaType {
-  if ("innerType" in schema.def) {
-    return getBaseSchema(schema.def.innerType as SchemaType);
+  if ("innerType" in schema._zod.def) {
+    return getBaseSchema(schema._zod.def.innerType as SchemaType);
   }
 
   return schema as SchemaType;
+}
+
+function isOptional<SchemaType extends z.$ZodType>(
+  schema: SchemaType | z.$ZodDefault<SchemaType>
+): boolean {
+  if(schema._zod.def.type === "optional") {
+    return true;
+  }
+
+  if ("innerType" in schema._zod.def) {
+    return isOptional(schema._zod.def.innerType as SchemaType);
+  }
+
+  return false;
 }

--- a/packages/zod/src/v4/schema-parser.ts
+++ b/packages/zod/src/v4/schema-parser.ts
@@ -37,7 +37,7 @@ function parseField(key: string, schema: z.$ZodType): ParsedField {
     type,
     required: !isOptional(schema),
     default: defaultValue,
-    description: z.globalRegistry.get(schema)?.description,
+    description: getDescription(schema),
     fieldConfig,
     options: optionValues,
     schema: subSchema,
@@ -65,9 +65,9 @@ function getBaseSchema<SchemaType extends z.$ZodType>(
 }
 
 function isOptional<SchemaType extends z.$ZodType>(
-  schema: SchemaType | z.$ZodDefault<SchemaType>
+  schema: SchemaType
 ): boolean {
-  if(schema._zod.def.type === "optional") {
+  if (schema._zod.def.type === "optional") {
     return true;
   }
 
@@ -76,4 +76,19 @@ function isOptional<SchemaType extends z.$ZodType>(
   }
 
   return false;
+}
+
+function getDescription<SchemaType extends z.$ZodType>(
+  schema: SchemaType
+): string | undefined {
+  const description = z.globalRegistry.get(schema)?.description;
+  if (description) {
+    return description;
+  }
+
+  if ("innerType" in schema._zod.def) {
+    return getDescription(schema._zod.def.innerType as SchemaType);
+  }
+
+  return undefined;
 }

--- a/packages/zod/src/v4/validator.ts
+++ b/packages/zod/src/v4/validator.ts
@@ -1,11 +1,11 @@
-import { z } from "zod/v4";
+import * as z from "zod/v4/core";
 
-export function validateSchema(schema: z.ZodObject, values: any) {
+export function validateSchema(schema: z.$ZodObject, values: any) {
   try {
-    schema.parse(values);
+    z.parse(schema, values);
     return { success: true, data: values };
   } catch (error) {
-    if (error instanceof z.ZodError) {
+    if (error instanceof z.$ZodError) {
       return { success: false, errors: error.issues };
     }
     throw error;


### PR DESCRIPTION
Utilizes `zod/v4/core` to implement **V4-mini** functionality in the `@autoform/zod/v4` package without affecting existing behavior.

[Reference - zod](https://zod.dev/library-authors#how-to-support-zod-and-zod-mini-simultaneously)

