### PR TITLE
fix: update zod package to use the zod^4.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22048,7 +22048,7 @@
         "zod": "^3.25.46"
       },
       "peerDependencies": {
-        "zod": "^3"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/zod/node_modules/@types/node": {

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "zod": "^3"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/zod/src/v3/default-values.ts
+++ b/packages/zod/src/v3/default-values.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { ZodObjectOrWrapped } from "./types";
 
 export function getDefaultValueInZodStack(schema: z.ZodTypeAny): any {
@@ -14,7 +14,7 @@ export function getDefaultValueInZodStack(schema: z.ZodTypeAny): any {
 }
 
 export function getDefaultValues(
-  schema: ZodObjectOrWrapped,
+  schema: ZodObjectOrWrapped
 ): Record<string, any> {
   const objectSchema =
     schema instanceof z.ZodEffects ? schema.innerType() : schema;

--- a/packages/zod/src/v3/field-config.ts
+++ b/packages/zod/src/v3/field-config.ts
@@ -1,4 +1,4 @@
-import { RefinementEffect, z } from "zod";
+import { RefinementEffect, z } from "zod/v3";
 import { FieldConfig } from "@autoform/core";
 import { ZOD_FIELD_CONFIG_SYMBOL } from "../utils";
 export type SuperRefineFunction = () => unknown;

--- a/packages/zod/src/v3/field-type-inference.ts
+++ b/packages/zod/src/v3/field-type-inference.ts
@@ -1,9 +1,9 @@
 import { FieldConfig } from "@autoform/core";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export function inferFieldType(
   schema: z.ZodTypeAny,
-  fieldConfig?: FieldConfig,
+  fieldConfig?: FieldConfig
 ): string {
   if (fieldConfig?.fieldType) {
     return fieldConfig.fieldType;

--- a/packages/zod/src/v3/provider.ts
+++ b/packages/zod/src/v3/provider.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { SchemaProvider, ParsedSchema, SchemaValidation } from "@autoform/core";
 import { getDefaultValues } from "./default-values";
 import { parseSchema } from "./schema-parser";

--- a/packages/zod/src/v3/schema-parser.ts
+++ b/packages/zod/src/v3/schema-parser.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { inferFieldType } from "./field-type-inference";
 import { getDefaultValueInZodStack } from "./default-values";
 import { getFieldConfigInZodStack } from "./field-config";
@@ -26,7 +26,7 @@ function parseField(key: string, schema: z.ZodTypeAny): ParsedField {
   let subSchema: ParsedField[] = [];
   if (baseSchema instanceof z.ZodObject) {
     subSchema = Object.entries(baseSchema.shape).map(([key, field]) =>
-      parseField(key, field as z.ZodTypeAny),
+      parseField(key, field as z.ZodTypeAny)
     );
   }
   if (baseSchema instanceof z.ZodArray) {
@@ -64,7 +64,7 @@ export function parseSchema(schema: ZodObjectOrWrapped): ParsedSchema {
   const shape = objectSchema.shape;
 
   const fields: ParsedField[] = Object.entries(shape).map(([key, field]) =>
-    parseField(key, field as z.ZodTypeAny),
+    parseField(key, field as z.ZodTypeAny)
   );
 
   return { fields };

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export type ZodObjectOrWrapped =
   | z.ZodObject<any, any>

--- a/packages/zod/src/v3/validator.ts
+++ b/packages/zod/src/v3/validator.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { ZodObjectOrWrapped } from "./types";
 
 export function validateSchema(schema: ZodObjectOrWrapped, values: any) {


### PR DESCRIPTION
This commit updates the `peerDependencies` to: 

```json
"zod": "^3.25.0 || ^4.0.0"
```
- As **zod 4.0.0 has been released on July 10th, 2025**
  Ref: [Zod documentation for library authors](https://zod.dev/library-authors)
  Ref; [How to support Zod 4?](https://zod.dev/library-authors?id=how-to-support-zod-4)
- Fixes peer‑dependency errors when installing with latest zod^4.0.0  [#187 comment](https://github.com/vantezzen/autoform/issues/187#issuecomment-3124266898)
- Continue to support combined `ZodProvider` and `fieldConfig` usage.

### Compatibility Notes
- Zod < 3.25.0 does **not** expose a `/v3` subpath.  
- Projects on Zod < 3.25.0 must continue using `@autoform/zod@^4.0.0`.  
- This new package requires Zod ≥ 3.25.0. to support ^4.0.0