### PR TITLE
feat: add Zod ^4.0.0 support, update peer deps, tests, and docs

### DIFF
--- a/.changeset/twenty-donkeys-ask.md
+++ b/.changeset/twenty-donkeys-ask.md
@@ -1,0 +1,28 @@
+---
+"@autoform/zod": major
+---
+
+BREAKING CHANGES
+
+- Requires `zod` version: `^3.25.0 || ^4.0.0`
+- Unified `ZodProvider` and `fieldConfig` for Zod v3, v4, and zod/mini:
+
+  ```ts
+  import { ZodProvider, fieldConfig } from "@autoform/zod";
+  ```
+
+- Field Configuration `fieldConfig`:
+  - Zod v3 uses `.superRefine()`:
+
+    ```ts
+    username: z.string().superRefine(
+      fieldConfig({ description: "You cannot change this later." })
+    );
+    ```
+
+  - Zod v4 uses `.check()`:
+    ```ts
+    username: z.string().check(
+      fieldConfig({ description: "You cannot change this later." })
+    );
+    ```

--- a/README.md
+++ b/README.md
@@ -18,19 +18,22 @@ What is AutoForm? Let's say you have a zod schema that you already use for your 
 
 ```ts
 import { z } from "zod";
+import { ZodProvider } from "@autoform/zod";
 
 const userSchema = z.object({
   name: z.string(),
   birthday: z.coerce.date(),
   email: z.string().email(),
 });
+
+export const schemaProvider = new ZodProvider(userSchema);
 ```
 
 With AutoForm, you can automatically render a form for this schema:
 
 ```tsx
 import { AutoForm } from "@autoform/mui";
-import { ZodProvider } from "@autoform/zod";
+import { schemaProvider } from "./schema";
 
 function MyForm() {
   return (

--- a/apps/docs/app/global.css
+++ b/apps/docs/app/global.css
@@ -62,3 +62,7 @@
   --color-chart-4: hsl(280 65% 60%);
   --color-chart-5: hsl(340 75% 55%);
 }
+
+.MuiFormControlLabel-label {
+  color: rgba(0, 0, 0, 0.7);
+}

--- a/apps/docs/components/landing/interactive-demo.tsx
+++ b/apps/docs/components/landing/interactive-demo.tsx
@@ -1,7 +1,7 @@
 "use client";
 import React, { useEffect, useState } from "react";
 import Editor from "@monaco-editor/react";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoForm } from "@autoform/mui";
 import { SchemaProvider } from "@autoform/core";
 import { ZodProvider } from "@autoform/zod";

--- a/apps/docs/components/landing/interactive-demo.tsx
+++ b/apps/docs/components/landing/interactive-demo.tsx
@@ -66,7 +66,7 @@ function InteractiveDemo() {
         />
       </div>
 
-      <div className="bg-white rounded-lg p-6">
+      <div className="bg-white rounded-lg p-6 pb-20 md:pb-24">
         <AutoForm
           schema={schemaProvider}
           onSubmit={(data) => setData(JSON.stringify(data, null, 2))}

--- a/apps/docs/components/landing/sections/hero.tsx
+++ b/apps/docs/components/landing/sections/hero.tsx
@@ -73,7 +73,7 @@ export const HeroSection = () => {
             <InteractiveDemo />
           </div>
 
-          <div className="absolute bottom-0 left-0 w-full h-20 md:h-28 bg-gradient-to-b from-background/0 via-background/50 to-background rounded-lg"></div>
+          <div className="absolute bottom-0 left-0 w-full h-20 md:h-24 bg-gradient-to-b from-background/0 via-background/50 to-background rounded-lg"></div>
         </div>
       </div>
     </section>

--- a/apps/docs/content/docs/index.mdx
+++ b/apps/docs/content/docs/index.mdx
@@ -7,19 +7,22 @@ What is AutoForm? Let's say you have a zod or yup schema that you already use fo
 
 ```ts
 import { z } from "zod";
+import { ZodProvider } from "@autoform/zod";
 
 const userSchema = z.object({
   name: z.string(),
   birthday: z.coerce.date(),
   email: z.string().email(),
 });
+
+export const schemaProvider = new ZodProvider(userSchema);
 ```
 
 With AutoForm, you can automatically render a form for this schema:
 
 ```tsx
 import { AutoForm } from "@autoform/mui";
-import { ZodProvider } from "@autoform/zod";
+import { schemaProvider } from "./schema";
 
 function MyForm() {
   return (

--- a/apps/docs/content/docs/schema-providers/zod.md
+++ b/apps/docs/content/docs/schema-providers/zod.md
@@ -353,7 +353,7 @@ With Zod mini, you apply this configuration using the `.check()` method.
 ```tsx
 import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { AutoForm, FieldTypes } from "@autoform/mui";
-import * as z from "zod/v4-mini";
+import * as z from "zod/mini";
 
 // Define your form schema using zod mini
 const formSchemaMini = z.object({

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -26,12 +26,13 @@
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-separator": "^1.1.7",
     "fumadocs-core": "15.5.3",
-    "fumadocs-mdx": "11.6.9",
+    "fumadocs-mdx": "11.7.1",
     "fumadocs-ui": "15.5.3",
     "lucide-react": "^0.522.0",
     "next": "15.3.3",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "zod": "^4.0.10"
   },
   "devDependencies": {
     "@tailwindcss/postcss": "^4.1.10",

--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -1,6 +1,6 @@
 import { FieldWrapperProps, buildZodFieldConfig } from "@autoform/react";
 import Joi from "joi";
-import * as z from "zod";
+import * as z from "zod/v3";
 import * as z4 from "zod/v4";
 import * as zm from "zod/v4-mini";
 import { ZodProvider, fieldConfig } from "@autoform/zod";

--- a/apps/web/components/utils.tsx
+++ b/apps/web/components/utils.tsx
@@ -2,7 +2,7 @@ import { FieldWrapperProps, buildZodFieldConfig } from "@autoform/react";
 import Joi from "joi";
 import * as z from "zod/v3";
 import * as z4 from "zod/v4";
-import * as zm from "zod/v4-mini";
+import * as zm from "zod/mini";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
 import { object, string, number, date, array, mixed } from "yup";
 import { YupProvider, fieldConfig as yupFieldConfig } from "@autoform/yup";

--- a/apps/web/cypress/component/autoform/ant-zod/advanced-features.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/advanced-features.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Advanced Features Tests (ANT-ZOD)", () => {
   const advancedSchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod/arrays.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/arrays.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Arrays Tests (ANT-ZOD)", () => {
   const arraySchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/basic.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Basic Tests (ANT-ZOD)", () => {
   const basicSchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod/controlled-form.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/controlled-form.cy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const ControlledForm = () => {
   const [formValues, setFormValues] = useState({

--- a/apps/web/cypress/component/autoform/ant-zod/custom-fields.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/custom-fields.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { fieldConfig, ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoFormFieldProps } from "@autoform/react";
 
 describe("AutoForm Custom Fields Tests (ANT-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/ant-zod/form-props.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/form-props.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Form Props Tests (ANT-ZOD)", () => {
   const schema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod/subobjects.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/subobjects.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Sub-objects Tests (ANT-ZOD)", () => {
   const subObjectSchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod/ui-customization.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/ui-customization.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TextField } from "@mui/material";
 import { FieldWrapperProps } from "@autoform/react";
 

--- a/apps/web/cypress/component/autoform/ant-zod/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Validation Tests (ANT-ZOD)", () => {
   const validationSchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod4-mini/basics.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod4-mini/basics.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 
 describe("AutoForm Basic Tests (ANT-ZOD-V4-MINI)", () => {
   const basicSchema = z.object({

--- a/apps/web/cypress/component/autoform/ant-zod4-mini/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/ant-zod4-mini/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/ant";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod/v4-mini";
+import { z } from "zod/mini";
 
 describe("AutoForm Validation Tests (ANT-ZOD-V4-MINI)", () => {
   const validationSchema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/advanced-features.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/advanced-features.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Advanced Features Tests (CHAKRA-ZOD)", () => {
   const advancedSchema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/arrays.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/arrays.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Arrays Tests (CHAKRA-ZOD)", () => {
   const arraySchema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/basic.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Basic Tests (CHAKRA-ZOD)", () => {
   const basicSchema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/controlled-form.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/controlled-form.cy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const ControlledForm = () => {
   const [formValues, setFormValues] = useState({

--- a/apps/web/cypress/component/autoform/chakra-zod/custom-fields.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/custom-fields.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { fieldConfig, ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoFormFieldProps } from "@autoform/react";
 
 describe("AutoForm Custom Fields Tests (CHAKRA-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/chakra-zod/form-props.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/form-props.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Form Props Tests (CHAKRA-ZOD)", () => {
   const schema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/subobjects.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/subobjects.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Sub-objects Tests (CHAKRA-ZOD)", () => {
   const subObjectSchema = z.object({

--- a/apps/web/cypress/component/autoform/chakra-zod/ui-customization.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/ui-customization.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TextField } from "@mui/material";
 import { FieldWrapperProps } from "@autoform/react";
 

--- a/apps/web/cypress/component/autoform/chakra-zod/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/chakra-zod/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/chakra";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Validation Tests (CHAKRA-ZOD)", () => {
   const validationSchema = z.object({

--- a/apps/web/cypress/component/autoform/mantine-zod/advanced-features.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/advanced-features.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Advanced Features Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/arrays.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/arrays.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Arrays Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/basic.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Basic Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/controlled-form.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/controlled-form.cy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 const ControlledForm = () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/custom-fields.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/custom-fields.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { fieldConfig, ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoFormFieldProps } from "@autoform/react";
 import { TestWrapper } from "./utils";
 

--- a/apps/web/cypress/component/autoform/mantine-zod/form-props.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/form-props.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Form Props Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/subobjects.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/subobjects.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Sub-objects Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mantine-zod/ui-customization.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/ui-customization.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TextField } from "@mui/material";
 import { TestWrapper } from "./utils";
 import { FieldWrapperProps } from "@autoform/react";

--- a/apps/web/cypress/component/autoform/mantine-zod/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/mantine-zod/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mantine";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Validation Tests (MANTINE-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mui-zod/advanced-features.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/advanced-features.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Advanced Features Tests (MUI-ZOD)", () => {
   const advancedSchema = z.object({

--- a/apps/web/cypress/component/autoform/mui-zod/arrays.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/arrays.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Arrays Tests (MUI-ZOD)", () => {
   const arraySchema = z.object({

--- a/apps/web/cypress/component/autoform/mui-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/basic.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Basic Tests (MUI-ZOD)", () => {
   const basicSchema = z.object({

--- a/apps/web/cypress/component/autoform/mui-zod/controlled-form.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/controlled-form.cy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const ControlledForm = () => {
   const [formValues, setFormValues] = useState({

--- a/apps/web/cypress/component/autoform/mui-zod/custom-fields.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/custom-fields.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { fieldConfig, ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoFormFieldProps } from "@autoform/react";
 
 describe("AutoForm Custom Fields Tests (MUI-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/mui-zod/form-props.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/form-props.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Form Props Tests (MUI-ZOD)", () => {
   const schema = z.object({

--- a/apps/web/cypress/component/autoform/mui-zod/subobjects.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/subobjects.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Sub-objects Tests (MUI-ZOD)", () => {
   const subObjectSchema = z.object({

--- a/apps/web/cypress/component/autoform/mui-zod/ui-customization.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/ui-customization.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TextField } from "@mui/material";
 import { FieldWrapperProps } from "@autoform/react";
 

--- a/apps/web/cypress/component/autoform/mui-zod/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/mui-zod/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/mui";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 describe("AutoForm Validation Tests (MUI-ZOD)", () => {
   const validationSchema = z.object({

--- a/apps/web/cypress/component/autoform/shadcn-zod/advanced-features.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/advanced-features.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Advanced Features Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/arrays.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/arrays.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Arrays Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/basic.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/basic.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Basic Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/controlled-form.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/controlled-form.cy.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 const ControlledForm = () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/custom-fields.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/custom-fields.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { fieldConfig, ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { AutoFormFieldProps } from "@autoform/react";
 import { TestWrapper } from "./utils";
 

--- a/apps/web/cypress/component/autoform/shadcn-zod/enums.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/enums.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Enums Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/form-props.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/form-props.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Form Props Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/subobjects.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/subobjects.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Sub-objects Tests (SHADCN-ZOD)", () => {

--- a/apps/web/cypress/component/autoform/shadcn-zod/ui-customization.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/ui-customization.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider, fieldConfig } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TextField } from "@mui/material";
 import { TestWrapper } from "./utils";
 import { FieldWrapperProps } from "@autoform/react";

--- a/apps/web/cypress/component/autoform/shadcn-zod/validation.cy.tsx
+++ b/apps/web/cypress/component/autoform/shadcn-zod/validation.cy.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import { AutoForm } from "@autoform/shadcn/components/ui/autoform/AutoForm";
 import { ZodProvider } from "@autoform/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { TestWrapper } from "./utils";
 
 describe("AutoForm Validation Tests (SHADCN-ZOD)", () => {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -31,7 +31,7 @@
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "yup": "^1.4.0",
-    "zod": "^3.25.67"
+    "zod": "^4.0.10"
   },
   "devDependencies": {
     "@autoform/eslint-config": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,12 +36,13 @@
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-separator": "^1.1.7",
         "fumadocs-core": "15.5.3",
-        "fumadocs-mdx": "11.6.9",
+        "fumadocs-mdx": "11.7.1",
         "fumadocs-ui": "15.5.3",
         "lucide-react": "^0.522.0",
         "next": "15.3.3",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "zod": "^4.0.10"
       },
       "devDependencies": {
         "@tailwindcss/postcss": "^4.1.10",
@@ -65,15 +66,15 @@
       }
     },
     "apps/docs/node_modules/fumadocs-mdx": {
-      "version": "11.6.9",
-      "resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-11.6.9.tgz",
-      "integrity": "sha512-Gm29CFOpvBe8m8r4Es0U6xsVvGaKEMiACsJeUYr6QdZiTYKXkl9a+gI6kkOfPJ/Aoyb561mh3Q0JSONX37GT5w==",
+      "version": "11.7.1",
+      "resolved": "https://registry.npmjs.org/fumadocs-mdx/-/fumadocs-mdx-11.7.1.tgz",
+      "integrity": "sha512-zY2s3OP0XsNhayp1ac3Qz/xSZLdfjFE3zCCt+LDlwAfRwlpP8WdwfUNsPzZSnnXYigLl0oEQNuL+SF4ZgXctfQ==",
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^3.1.0",
         "@standard-schema/spec": "^1.0.0",
         "chokidar": "^4.0.3",
-        "esbuild": "^0.25.5",
+        "esbuild": "^0.25.8",
         "estree-util-value-to-estree": "^3.4.0",
         "js-yaml": "^4.1.0",
         "lru-cache": "^11.1.0",
@@ -81,22 +82,26 @@
         "tinyexec": "^1.0.1",
         "tinyglobby": "^0.2.14",
         "unist-util-visit": "^5.0.0",
-        "zod": "^3.25.63"
+        "zod": "^4.0.10"
       },
       "bin": {
         "fumadocs-mdx": "bin.js"
       },
       "peerDependencies": {
-        "@fumadocs/mdx-remote": "^1.2.0",
+        "@fumadocs/mdx-remote": "^1.4.0",
         "fumadocs-core": "^14.0.0 || ^15.0.0",
         "next": "^15.3.0",
-        "vite": "6.x.x"
+        "react": "*",
+        "vite": "6.x.x || 7.x.x"
       },
       "peerDependenciesMeta": {
         "@fumadocs/mdx-remote": {
           "optional": true
         },
         "next": {
+          "optional": true
+        },
+        "react": {
           "optional": true
         },
         "vite": {
@@ -140,7 +145,7 @@
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "yup": "^1.4.0",
-        "zod": "^3.25.67"
+        "zod": "^4.0.10"
       },
       "devDependencies": {
         "@autoform/eslint-config": "*",
@@ -161,9 +166,9 @@
       }
     },
     "apps/web/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1322,9 +1327,9 @@
       "license": "MIT"
     },
     "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.5.tgz",
-      "integrity": "sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.8.tgz",
+      "integrity": "sha512-urAvrUedIqEiFR3FYSLTWQgLu5tb+m0qZw0NBEasUeo6wuqatkMDaRT+1uABiGXEu5vqgPd7FGE1BhsAIy9QVA==",
       "cpu": [
         "ppc64"
       ],
@@ -1338,9 +1343,9 @@
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.5.tgz",
-      "integrity": "sha512-AdJKSPeEHgi7/ZhuIPtcQKr5RQdo6OO2IL87JkianiMYMPbCtot9fxPbrMiBADOWWm3T2si9stAiVsGbTQFkbA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.8.tgz",
+      "integrity": "sha512-RONsAvGCz5oWyePVnLdZY/HHwA++nxYWIX1atInlaW6SEkwq6XkP3+cb825EUcRs5Vss/lGh/2YxAb5xqc07Uw==",
       "cpu": [
         "arm"
       ],
@@ -1354,9 +1359,9 @@
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.5.tgz",
-      "integrity": "sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.8.tgz",
+      "integrity": "sha512-OD3p7LYzWpLhZEyATcTSJ67qB5D+20vbtr6vHlHWSQYhKtzUYrETuWThmzFpZtFsBIxRvhO07+UgVA9m0i/O1w==",
       "cpu": [
         "arm64"
       ],
@@ -1370,9 +1375,9 @@
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.5.tgz",
-      "integrity": "sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.8.tgz",
+      "integrity": "sha512-yJAVPklM5+4+9dTeKwHOaA+LQkmrKFX96BM0A/2zQrbS6ENCmxc4OVoBs5dPkCCak2roAD+jKCdnmOqKszPkjA==",
       "cpu": [
         "x64"
       ],
@@ -1386,9 +1391,9 @@
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.5.tgz",
-      "integrity": "sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.8.tgz",
+      "integrity": "sha512-Jw0mxgIaYX6R8ODrdkLLPwBqHTtYHJSmzzd+QeytSugzQ0Vg4c5rDky5VgkoowbZQahCbsv1rT1KW72MPIkevw==",
       "cpu": [
         "arm64"
       ],
@@ -1402,9 +1407,9 @@
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.5.tgz",
-      "integrity": "sha512-1iT4FVL0dJ76/q1wd7XDsXrSW+oLoquptvh4CLR4kITDtqi2e/xwXwdCVH8hVHU43wgJdsq7Gxuzcs6Iq/7bxQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.8.tgz",
+      "integrity": "sha512-Vh2gLxxHnuoQ+GjPNvDSDRpoBCUzY4Pu0kBqMBDlK4fuWbKgGtmDIeEC081xi26PPjn+1tct+Bh8FjyLlw1Zlg==",
       "cpu": [
         "x64"
       ],
@@ -1418,9 +1423,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-YPJ7hDQ9DnNe5vxOm6jaie9QsTwcKedPvizTVlqWG9GBSq+BuyWEDazlGaDTC5NGU4QJd666V0yqCBL2oWKPfA==",
       "cpu": [
         "arm64"
       ],
@@ -1434,9 +1439,9 @@
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.5.tgz",
-      "integrity": "sha512-PrikaNjiXdR2laW6OIjlbeuCPrPaAl0IwPIaRv+SMV8CiM8i2LqVUHFC1+8eORgWyY7yhQY+2U2fA55mBzReaw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.8.tgz",
+      "integrity": "sha512-MmaEXxQRdXNFsRN/KcIimLnSJrk2r5H8v+WVafRWz5xdSVmWLoITZQXcgehI2ZE6gioE6HirAEToM/RvFBeuhw==",
       "cpu": [
         "x64"
       ],
@@ -1450,9 +1455,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.5.tgz",
-      "integrity": "sha512-cPzojwW2okgh7ZlRpcBEtsX7WBuqbLrNXqLU89GxWbNt6uIg78ET82qifUy3W6OVww6ZWobWub5oqZOVtwolfw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.8.tgz",
+      "integrity": "sha512-FuzEP9BixzZohl1kLf76KEVOsxtIBFwCaLupVuk4eFVnOZfU+Wsn+x5Ryam7nILV2pkq2TqQM9EZPsOBuMC+kg==",
       "cpu": [
         "arm"
       ],
@@ -1466,9 +1471,9 @@
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.5.tgz",
-      "integrity": "sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.8.tgz",
+      "integrity": "sha512-WIgg00ARWv/uYLU7lsuDK00d/hHSfES5BzdWAdAig1ioV5kaFNrtK8EqGcUBJhYqotlUByUKz5Qo6u8tt7iD/w==",
       "cpu": [
         "arm64"
       ],
@@ -1482,9 +1487,9 @@
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.5.tgz",
-      "integrity": "sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.8.tgz",
+      "integrity": "sha512-A1D9YzRX1i+1AJZuFFUMP1E9fMaYY+GnSQil9Tlw05utlE86EKTUA7RjwHDkEitmLYiFsRd9HwKBPEftNdBfjg==",
       "cpu": [
         "ia32"
       ],
@@ -1498,9 +1503,9 @@
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.5.tgz",
-      "integrity": "sha512-0ur7ae16hDUC4OL5iEnDb0tZHDxYmuQyhKhsPBV8f99f6Z9KQM02g33f93rNH5A30agMS46u2HP6qTdEt6Q1kg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.8.tgz",
+      "integrity": "sha512-O7k1J/dwHkY1RMVvglFHl1HzutGEFFZ3kNiDMSOyUrB7WcoHGf96Sh+64nTRT26l3GMbCW01Ekh/ThKM5iI7hQ==",
       "cpu": [
         "loong64"
       ],
@@ -1514,9 +1519,9 @@
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.5.tgz",
-      "integrity": "sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.8.tgz",
+      "integrity": "sha512-uv+dqfRazte3BzfMp8PAQXmdGHQt2oC/y2ovwpTteqrMx2lwaksiFZ/bdkXJC19ttTvNXBuWH53zy/aTj1FgGw==",
       "cpu": [
         "mips64el"
       ],
@@ -1530,9 +1535,9 @@
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.5.tgz",
-      "integrity": "sha512-UZCmJ7r9X2fe2D6jBmkLBMQetXPXIsZjQJCjgwpVDz+YMcS6oFR27alkgGv3Oqkv07bxdvw7fyB71/olceJhkQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.8.tgz",
+      "integrity": "sha512-GyG0KcMi1GBavP5JgAkkstMGyMholMDybAf8wF5A70CALlDM2p/f7YFE7H92eDeH/VBtFJA5MT4nRPDGg4JuzQ==",
       "cpu": [
         "ppc64"
       ],
@@ -1546,9 +1551,9 @@
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.5.tgz",
-      "integrity": "sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.8.tgz",
+      "integrity": "sha512-rAqDYFv3yzMrq7GIcen3XP7TUEG/4LK86LUPMIz6RT8A6pRIDn0sDcvjudVZBiiTcZCY9y2SgYX2lgK3AF+1eg==",
       "cpu": [
         "riscv64"
       ],
@@ -1562,9 +1567,9 @@
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.5.tgz",
-      "integrity": "sha512-K2dSKTKfmdh78uJ3NcWFiqyRrimfdinS5ErLSn3vluHNeHVnBAFWC8a4X5N+7FgVE1EjXS1QDZbpqZBjfrqMTQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.8.tgz",
+      "integrity": "sha512-Xutvh6VjlbcHpsIIbwY8GVRbwoviWT19tFhgdA7DlenLGC/mbc3lBoVb7jxj9Z+eyGqvcnSyIltYUrkKzWqSvg==",
       "cpu": [
         "s390x"
       ],
@@ -1578,9 +1583,9 @@
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.5.tgz",
-      "integrity": "sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.8.tgz",
+      "integrity": "sha512-ASFQhgY4ElXh3nDcOMTkQero4b1lgubskNlhIfJrsH5OKZXDpUAKBlNS0Kx81jwOBp+HCeZqmoJuihTv57/jvQ==",
       "cpu": [
         "x64"
       ],
@@ -1594,9 +1599,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-d1KfruIeohqAi6SA+gENMuObDbEjn22olAR7egqnkCD9DGBG0wsEARotkLgXDu6c4ncgWTZJtN5vcgxzWRMzcw==",
       "cpu": [
         "arm64"
       ],
@@ -1610,9 +1615,9 @@
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-WOb5fKrvVTRMfWFNCroYWWklbnXH0Q5rZppjq0vQIdlsQKuw6mdSihwSo4RV/YdQ5UCKKvBy7/0ZZYLBZKIbwQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-nVDCkrvx2ua+XQNyfrujIG38+YGyuy2Ru9kKVNyh5jAys6n+l44tTtToqHjino2My8VAY6Lw9H7RI73XFi66Cg==",
       "cpu": [
         "x64"
       ],
@@ -1626,9 +1631,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.5.tgz",
-      "integrity": "sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.8.tgz",
+      "integrity": "sha512-j8HgrDuSJFAujkivSMSfPQSAa5Fxbvk4rgNAS5i3K+r8s1X0p1uOO2Hl2xNsGFppOeHOLAVgYwDVlmxhq5h+SQ==",
       "cpu": [
         "arm64"
       ],
@@ -1642,9 +1647,9 @@
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.5.tgz",
-      "integrity": "sha512-G4hE405ErTWraiZ8UiSoesH8DaCsMm0Cay4fsFWOOUcz8b8rC6uCvnagr+gnioEjWn0wC+o1/TAHt+It+MpIMg==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.8.tgz",
+      "integrity": "sha512-1h8MUAwa0VhNCDp6Af0HToI2TJFAn1uqT9Al6DJVzdIBAd21m/G0Yfc77KDM3uF3T/YaOgQq3qTJHPbTOInaIQ==",
       "cpu": [
         "x64"
       ],
@@ -1657,10 +1662,26 @@
         "node": ">=18"
       }
     },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.8.tgz",
+      "integrity": "sha512-r2nVa5SIK9tSWd0kJd9HCffnDHKchTGikb//9c7HX+r+wHYCpQrSgxhlY6KWV1nFo1l4KFbsMlHk+L6fekLsUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.5.tgz",
-      "integrity": "sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.8.tgz",
+      "integrity": "sha512-zUlaP2S12YhQ2UzUfcCuMDHQFJyKABkAjvO5YSndMiIkMimPmxA+BYSBikWgsRpvyxuRnow4nS5NPnf9fpv41w==",
       "cpu": [
         "x64"
       ],
@@ -1674,9 +1695,9 @@
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.5.tgz",
-      "integrity": "sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.8.tgz",
+      "integrity": "sha512-YEGFFWESlPva8hGL+zvj2z/SaK+pH0SwOM0Nc/d+rVnW7GSTFlLBGzZkuSU9kFIGIo8q9X3ucpZhu8PDN5A2sQ==",
       "cpu": [
         "arm64"
       ],
@@ -1690,9 +1711,9 @@
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.5.tgz",
-      "integrity": "sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.8.tgz",
+      "integrity": "sha512-hiGgGC6KZ5LZz58OL/+qVVoZiuZlUYlYHNAmczOm7bs2oE1XriPFi5ZHHrS8ACpV5EjySrnoCKmcbQMN+ojnHg==",
       "cpu": [
         "ia32"
       ],
@@ -1706,9 +1727,9 @@
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.5.tgz",
-      "integrity": "sha512-TXv6YnJ8ZMVdX+SXWVBo/0p8LTcrUYngpWjvm91TMjjBQii7Oz11Lw5lbDV5Y0TzuhSJHwiH4hEtC1I42mMS0g==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.8.tgz",
+      "integrity": "sha512-cn3Yr7+OaaZq1c+2pe+8yxC8E144SReCQjN6/2ynubzYjvyqZjTXfQJpAcQpsdJq3My7XADANiYGHoFC69pLQw==",
       "cpu": [
         "x64"
       ],
@@ -2584,9 +2605,9 @@
       "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.25",
-      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
-      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "version": "0.3.29",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.29.tgz",
+      "integrity": "sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
@@ -2734,12 +2755,12 @@
       }
     },
     "node_modules/@mdx-js/mdx/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -4853,9 +4874,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@swc/helpers": {
-      "version": "0.5.17",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.17.tgz",
-      "integrity": "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A==",
+      "version": "0.5.15",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
+      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
@@ -5582,17 +5603,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.0.tgz",
-      "integrity": "sha512-ijItUYaiWuce0N1SoSMrEd0b6b6lYkYt99pqCPfybd+HKVXtEvYhICfLdwp42MhiI5mp0oq7PKEL+g1cNiz/Eg==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.38.0.tgz",
+      "integrity": "sha512-CPoznzpuAnIOl4nhj4tRr4gIPj5AfKgkiJmGQDaq+fQnRJTYlcBjbX3wbciGmpoPf8DREufuPRe1tNMZnGdanA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.35.0",
-        "@typescript-eslint/type-utils": "8.35.0",
-        "@typescript-eslint/utils": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0",
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/type-utils": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "graphemer": "^1.4.0",
         "ignore": "^7.0.0",
         "natural-compare": "^1.4.0",
@@ -5606,7 +5627,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.35.0",
+        "@typescript-eslint/parser": "^8.38.0",
         "eslint": "^8.57.0 || ^9.0.0",
         "typescript": ">=4.8.4 <5.9.0"
       }
@@ -5622,16 +5643,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.35.0.tgz",
-      "integrity": "sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.38.0.tgz",
+      "integrity": "sha512-Zhy8HCvBUEfBECzIl1PKqF4p11+d0aUJS1GeUiuqK9WmOug8YCmC4h4bjyBvMyAMI9sbRczmrYL5lKg/YMbrcQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/typescript-estree": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0",
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5647,14 +5668,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.35.0.tgz",
-      "integrity": "sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.38.0.tgz",
+      "integrity": "sha512-dbK7Jvqcb8c9QfH01YB6pORpqX1mn5gDZc9n63Ak/+jD67oWXn3Gs0M6vddAN+eDXBCS5EmNWzbSxsn9SzFWWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.35.0",
-        "@typescript-eslint/types": "^8.35.0",
+        "@typescript-eslint/tsconfig-utils": "^8.38.0",
+        "@typescript-eslint/types": "^8.38.0",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -5669,14 +5690,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz",
-      "integrity": "sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.38.0.tgz",
+      "integrity": "sha512-WJw3AVlFFcdT9Ri1xs/lg8LwDqgekWXWhH3iAF+1ZM+QPd7oxQ6jvtW/JPwzAScxitILUIFs0/AnQ/UWHzbATQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0"
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5687,9 +5708,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz",
-      "integrity": "sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.38.0.tgz",
+      "integrity": "sha512-Lum9RtSE3EroKk/bYns+sPOodqb2Fv50XOl/gMviMKNvanETUuUcC9ObRbzrJ4VSd2JalPqgSAavwrPiPvnAiQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5704,14 +5725,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.35.0.tgz",
-      "integrity": "sha512-ceNNttjfmSEoM9PW87bWLDEIaLAyR+E6BoYJQ5PfaDau37UGca9Nyq3lBk8Bw2ad0AKvYabz6wxc7DMTO2jnNA==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.38.0.tgz",
+      "integrity": "sha512-c7jAvGEZVf0ao2z+nnz8BUaHZD09Agbh+DY7qvBQqLiz8uJzRgVPj5YvOh8I8uEiH8oIUGIfHzMwUcGVco/SJg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.35.0",
-        "@typescript-eslint/utils": "8.35.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0",
+        "@typescript-eslint/utils": "8.38.0",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.1.0"
       },
@@ -5728,9 +5750,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.35.0.tgz",
-      "integrity": "sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.38.0.tgz",
+      "integrity": "sha512-wzkUfX3plUqij4YwWaJyqhiPE5UCRVlFpKn1oCRn2O1bJ592XxWJj8ROQ3JD5MYXLORW84063z3tZTb/cs4Tyw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -5742,16 +5764,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz",
-      "integrity": "sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.38.0.tgz",
+      "integrity": "sha512-fooELKcAKzxux6fA6pxOflpNS0jc+nOQEEOipXFNjSlBS6fqrJOVY/whSn70SScHrcJ2LDsxWrneFoWYSVfqhQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.35.0",
-        "@typescript-eslint/tsconfig-utils": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/visitor-keys": "8.35.0",
+        "@typescript-eslint/project-service": "8.38.0",
+        "@typescript-eslint/tsconfig-utils": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/visitor-keys": "8.38.0",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -5771,16 +5793,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.35.0.tgz",
-      "integrity": "sha512-nqoMu7WWM7ki5tPgLVsmPM8CkqtoPUG6xXGeefM5t4x3XumOEKMoUZPdi+7F+/EotukN4R9OWdmDxN80fqoZeg==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.38.0.tgz",
+      "integrity": "sha512-hHcMA86Hgt+ijJlrD8fX0j1j8w4C92zue/8LOPAFioIno+W0+L7KqE8QZKCcPGc/92Vs9x36w/4MPTJhqXdyvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.35.0",
-        "@typescript-eslint/types": "8.35.0",
-        "@typescript-eslint/typescript-estree": "8.35.0"
+        "@typescript-eslint/scope-manager": "8.38.0",
+        "@typescript-eslint/types": "8.38.0",
+        "@typescript-eslint/typescript-estree": "8.38.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5795,13 +5817,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.35.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz",
-      "integrity": "sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==",
+      "version": "8.38.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.38.0.tgz",
+      "integrity": "sha512-pWrTcoFNWuwHlA9CvlfSsGWs14JxfN1TH25zM5L7o0pRLhsoZkDnTsXfQRJBEWJoV5DL0jf+Z+sxiud+K0mq1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.35.0",
+        "@typescript-eslint/types": "8.38.0",
         "eslint-visitor-keys": "^4.2.1"
       },
       "engines": {
@@ -8600,9 +8622,9 @@
       }
     },
     "node_modules/cypress/node_modules/ci-info": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.2.0.tgz",
-      "integrity": "sha512-cYY9mypksY8NRqgDB1XD1RiJL338v/551niynFTGkZOO2LHuB2OmOYxDIe/ttN9AHwrqdum1360G3ald0W9kCg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.0.tgz",
+      "integrity": "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ==",
       "dev": true,
       "funding": [
         {
@@ -9473,9 +9495,9 @@
       }
     },
     "node_modules/esbuild": {
-      "version": "0.25.5",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.5.tgz",
-      "integrity": "sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==",
+      "version": "0.25.8",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.8.tgz",
+      "integrity": "sha512-vVC0USHGtMi8+R4Kz8rt6JhEWLxsv9Rnu/lGYbPR8u47B+DCBksq9JarW0zOO7bs37hyOK1l2/oqtbciutL5+Q==",
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -9485,31 +9507,32 @@
         "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.25.5",
-        "@esbuild/android-arm": "0.25.5",
-        "@esbuild/android-arm64": "0.25.5",
-        "@esbuild/android-x64": "0.25.5",
-        "@esbuild/darwin-arm64": "0.25.5",
-        "@esbuild/darwin-x64": "0.25.5",
-        "@esbuild/freebsd-arm64": "0.25.5",
-        "@esbuild/freebsd-x64": "0.25.5",
-        "@esbuild/linux-arm": "0.25.5",
-        "@esbuild/linux-arm64": "0.25.5",
-        "@esbuild/linux-ia32": "0.25.5",
-        "@esbuild/linux-loong64": "0.25.5",
-        "@esbuild/linux-mips64el": "0.25.5",
-        "@esbuild/linux-ppc64": "0.25.5",
-        "@esbuild/linux-riscv64": "0.25.5",
-        "@esbuild/linux-s390x": "0.25.5",
-        "@esbuild/linux-x64": "0.25.5",
-        "@esbuild/netbsd-arm64": "0.25.5",
-        "@esbuild/netbsd-x64": "0.25.5",
-        "@esbuild/openbsd-arm64": "0.25.5",
-        "@esbuild/openbsd-x64": "0.25.5",
-        "@esbuild/sunos-x64": "0.25.5",
-        "@esbuild/win32-arm64": "0.25.5",
-        "@esbuild/win32-ia32": "0.25.5",
-        "@esbuild/win32-x64": "0.25.5"
+        "@esbuild/aix-ppc64": "0.25.8",
+        "@esbuild/android-arm": "0.25.8",
+        "@esbuild/android-arm64": "0.25.8",
+        "@esbuild/android-x64": "0.25.8",
+        "@esbuild/darwin-arm64": "0.25.8",
+        "@esbuild/darwin-x64": "0.25.8",
+        "@esbuild/freebsd-arm64": "0.25.8",
+        "@esbuild/freebsd-x64": "0.25.8",
+        "@esbuild/linux-arm": "0.25.8",
+        "@esbuild/linux-arm64": "0.25.8",
+        "@esbuild/linux-ia32": "0.25.8",
+        "@esbuild/linux-loong64": "0.25.8",
+        "@esbuild/linux-mips64el": "0.25.8",
+        "@esbuild/linux-ppc64": "0.25.8",
+        "@esbuild/linux-riscv64": "0.25.8",
+        "@esbuild/linux-s390x": "0.25.8",
+        "@esbuild/linux-x64": "0.25.8",
+        "@esbuild/netbsd-arm64": "0.25.8",
+        "@esbuild/netbsd-x64": "0.25.8",
+        "@esbuild/openbsd-arm64": "0.25.8",
+        "@esbuild/openbsd-x64": "0.25.8",
+        "@esbuild/openharmony-arm64": "0.25.8",
+        "@esbuild/sunos-x64": "0.25.8",
+        "@esbuild/win32-arm64": "0.25.8",
+        "@esbuild/win32-ia32": "0.25.8",
+        "@esbuild/win32-x64": "0.25.8"
       }
     },
     "node_modules/escalade": {
@@ -10650,12 +10673,12 @@
       }
     },
     "node_modules/estree-util-to-js/node_modules/source-map": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
-      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.6.tgz",
+      "integrity": "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ==",
       "license": "BSD-3-Clause",
       "engines": {
-        "node": ">= 8"
+        "node": ">= 12"
       }
     },
     "node_modules/estree-util-value-to-estree": {
@@ -15259,15 +15282,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/@swc/helpers": {
-      "version": "0.5.15",
-      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.15.tgz",
-      "integrity": "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "tslib": "^2.8.0"
-      }
-    },
     "node_modules/next/node_modules/postcss": {
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
@@ -16523,9 +16537,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.6.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.1.tgz",
-      "integrity": "sha512-5xGWRa90Sp2+x1dQtNpIpeOQpTDBs9cZDmA/qs2vDNN2i18PdapqY7CmBeyLlMuGqXJRIOPaCaVZTLNQRWUH/A==",
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
+      "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -19460,9 +19474,9 @@
       }
     },
     "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
-      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -20820,9 +20834,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.25.67",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.67.tgz",
-      "integrity": "sha512-idA2YXwpCdqUSKRCACDE6ItZD9TZzy3OZMtpfLoh6oPR47lipysRrJfjzMqFxQ3uJuUPyUeWe1r9vLH33xO/Qw==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.0.10.tgz",
+      "integrity": "sha512-3vB+UU3/VmLL2lvwcY/4RV2i9z/YU0DTV/tDuYjrwmx5WeJ7hwy+rGEEx8glHp6Yxw7ibRbKSaIFBgReRPe5KA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
@@ -20869,9 +20883,9 @@
       }
     },
     "packages/ant/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20917,9 +20931,9 @@
       }
     },
     "packages/chakra/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -20950,9 +20964,9 @@
       }
     },
     "packages/core/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21693,9 +21707,9 @@
       }
     },
     "packages/joi/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21740,9 +21754,9 @@
       }
     },
     "packages/mantine/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21789,9 +21803,9 @@
       }
     },
     "packages/mui/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21836,9 +21850,9 @@
       }
     },
     "packages/react/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -21889,7 +21903,7 @@
         "tailwindcss-animate": "^1.0.7",
         "tsup": "^8.3.0",
         "typescript": "^5.3.3",
-        "zod": "^3.23.8"
+        "zod": "^4.0.10"
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19",
@@ -21898,9 +21912,9 @@
       }
     },
     "packages/shadcn/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22014,9 +22028,9 @@
       }
     },
     "packages/yup/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22045,16 +22059,16 @@
         "eslint": "^8.57.0",
         "tsup": "^8.3.0",
         "typescript": "^5.3.3",
-        "zod": "^3.25.46"
+        "zod": "^4.0.10"
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/zod/node_modules/@types/node": {
-      "version": "20.19.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.1.tgz",
-      "integrity": "sha512-jJD50LtlD2dodAEO653i3YF04NWak6jN3ky+Ri3Em3mGR39/glWiboM/IePaRbgwSfqM1TpGXfAg8ohn/4dTgA==",
+      "version": "20.19.9",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.9.tgz",
+      "integrity": "sha512-cuVNgarYWZqxRJDQHEB58GEONhOK79QVR/qYx4S7kcUObQvUwvFnYxJuuHUKm2aieN9X3yZB4LZsuYNU1Qphsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -22048,7 +22048,7 @@
         "zod": "^3.25.46"
       },
       "peerDependencies": {
-        "zod": "^3"
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "packages/zod/node_modules/@types/node": {

--- a/packages/shadcn/package.json
+++ b/packages/shadcn/package.json
@@ -42,7 +42,7 @@
     "tailwindcss-animate": "^1.0.7",
     "tsup": "^8.3.0",
     "typescript": "^5.3.3",
-    "zod": "^3.23.8"
+    "zod": "^4.0.10"
   },
   "dependencies": {
     "@autoform/react": "*",

--- a/packages/shadcn/src/scripts/build.ts
+++ b/packages/shadcn/src/scripts/build.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile } from "fs/promises";
-import { z } from "zod";
+import { z } from "zod/v3";
 import { registryEntrySchema } from "./schema";
 import { glob } from "glob";
 

--- a/packages/shadcn/src/scripts/schema.ts
+++ b/packages/shadcn/src/scripts/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const blockChunkSchema = z.object({
   name: z.string(),

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -25,9 +25,8 @@
     "eslint": "^8.57.0",
     "tsup": "^8.3.0",
     "typescript": "^5.3.3",
-    "zod": "^3.25.46"
+    "zod": "^4.0.10"
   },
-  "dependencies": {},
   "peerDependencies": {
     "zod": "^3.25.0 || ^4.0.0"
   }

--- a/packages/zod/package.json
+++ b/packages/zod/package.json
@@ -29,6 +29,6 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "zod": "^3"
+    "zod": "^3.25.0 || ^4.0.0"
   }
 }

--- a/packages/zod/src/v3/default-values.ts
+++ b/packages/zod/src/v3/default-values.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { ZodObjectOrWrapped } from "./types";
 
 export function getDefaultValueInZodStack(schema: z.ZodTypeAny): any {
@@ -14,7 +14,7 @@ export function getDefaultValueInZodStack(schema: z.ZodTypeAny): any {
 }
 
 export function getDefaultValues(
-  schema: ZodObjectOrWrapped,
+  schema: ZodObjectOrWrapped
 ): Record<string, any> {
   const objectSchema =
     schema instanceof z.ZodEffects ? schema.innerType() : schema;

--- a/packages/zod/src/v3/field-config.ts
+++ b/packages/zod/src/v3/field-config.ts
@@ -1,4 +1,4 @@
-import { RefinementEffect, z } from "zod";
+import { RefinementEffect, z } from "zod/v3";
 import { FieldConfig } from "@autoform/core";
 import { ZOD_FIELD_CONFIG_SYMBOL } from "../utils";
 export type SuperRefineFunction = () => unknown;

--- a/packages/zod/src/v3/field-type-inference.ts
+++ b/packages/zod/src/v3/field-type-inference.ts
@@ -1,9 +1,9 @@
 import { FieldConfig } from "@autoform/core";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export function inferFieldType(
   schema: z.ZodTypeAny,
-  fieldConfig?: FieldConfig,
+  fieldConfig?: FieldConfig
 ): string {
   if (fieldConfig?.fieldType) {
     return fieldConfig.fieldType;

--- a/packages/zod/src/v3/provider.ts
+++ b/packages/zod/src/v3/provider.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { SchemaProvider, ParsedSchema, SchemaValidation } from "@autoform/core";
 import { getDefaultValues } from "./default-values";
 import { parseSchema } from "./schema-parser";

--- a/packages/zod/src/v3/schema-parser.ts
+++ b/packages/zod/src/v3/schema-parser.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { inferFieldType } from "./field-type-inference";
 import { getDefaultValueInZodStack } from "./default-values";
 import { getFieldConfigInZodStack } from "./field-config";
@@ -26,7 +26,7 @@ function parseField(key: string, schema: z.ZodTypeAny): ParsedField {
   let subSchema: ParsedField[] = [];
   if (baseSchema instanceof z.ZodObject) {
     subSchema = Object.entries(baseSchema.shape).map(([key, field]) =>
-      parseField(key, field as z.ZodTypeAny),
+      parseField(key, field as z.ZodTypeAny)
     );
   }
   if (baseSchema instanceof z.ZodArray) {
@@ -64,7 +64,7 @@ export function parseSchema(schema: ZodObjectOrWrapped): ParsedSchema {
   const shape = objectSchema.shape;
 
   const fields: ParsedField[] = Object.entries(shape).map(([key, field]) =>
-    parseField(key, field as z.ZodTypeAny),
+    parseField(key, field as z.ZodTypeAny)
   );
 
   return { fields };

--- a/packages/zod/src/v3/types.ts
+++ b/packages/zod/src/v3/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export type ZodObjectOrWrapped =
   | z.ZodObject<any, any>

--- a/packages/zod/src/v3/validator.ts
+++ b/packages/zod/src/v3/validator.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 import { ZodObjectOrWrapped } from "./types";
 
 export function validateSchema(schema: ZodObjectOrWrapped, values: any) {


### PR DESCRIPTION
This commit 

1. Update `peerDependencies` to support both Zod v3.25.0+ and v4.0.0+

```json
"zod": "^3.25.0 || ^4.0.0"
```
    
   - Fixes install issues with zod ^4.0.0  [#187 comment](https://github.com/vantezzen/autoform/issues/187#issuecomment-3124266898)
   - Tests updated: `zod/v3` used for ui package tests, `zod/v4` used in `shadcn-zod4` test. All tests pass.
   - Added a working autoform example to the introduction part of the README and Docs [#187 comment](https://github.com/vantezzen/autoform/issues/187#issuecomment-3124303880)

2. Compatibility Notes
- Zod < 3.25.0 does **not** expose a `/v3` subpath. 
	Projects using older Zod versions should continue using `@autoform/zod@^4.0.0`.
	
- This version requires Zod ≥ 3.25.0 to support both  ^3.25.0  and  ^4.0.0.
	- **Zod 4.0.0 was released on July 8th, 2025**
	References:
  [Zod documentation for library authors](https://zod.dev/library-authors)
		[Users need to upgrade ](https://zod.dev/library-authors?id=do-i-need-to-publish-a-new-major-version) 
  [How to support Zod 4](https://zod.dev/library-authors?id=how-to-support-zod-4)
  
3. Other
	- Continue to support combined `ZodProvider` and `fieldConfig` usage.


